### PR TITLE
FFM-7275 - iOS SDK - SSE event stream doesn't time out when no data arrives

### DIFF
--- a/Sources/ff-ios-client-sdk/Events/EventSource.swift
+++ b/Sources/ff-ios-client-sdk/Events/EventSource.swift
@@ -203,9 +203,10 @@ internal extension EventSource {
 
         additionalHeaders["Accept"] = "text/event-stream"
         additionalHeaders["Cache-Control"] = "no-cache"
+        additionalHeaders["User-Agent"] = "ios 1.0.3"
 
         let sessionConfiguration = URLSessionConfiguration.default
-        sessionConfiguration.timeoutIntervalForRequest = TimeInterval(INT_MAX)
+        sessionConfiguration.timeoutIntervalForRequest = TimeInterval(60)
         sessionConfiguration.timeoutIntervalForResource = TimeInterval(INT_MAX)
         sessionConfiguration.httpAdditionalHeaders = additionalHeaders
 

--- a/Sources/ff-ios-client-sdk/Events/EventSource.swift
+++ b/Sources/ff-ios-client-sdk/Events/EventSource.swift
@@ -203,11 +203,11 @@ internal extension EventSource {
 
         additionalHeaders["Accept"] = "text/event-stream"
         additionalHeaders["Cache-Control"] = "no-cache"
-        additionalHeaders["User-Agent"] = "ios 1.0.3"
+        additionalHeaders["User-Agent"] = "ios " + Version.version
 
         let sessionConfiguration = URLSessionConfiguration.default
         sessionConfiguration.timeoutIntervalForRequest = TimeInterval(60)
-        sessionConfiguration.timeoutIntervalForResource = TimeInterval(INT_MAX)
+        sessionConfiguration.timeoutIntervalForResource = TimeInterval(86400)
         sessionConfiguration.httpAdditionalHeaders = additionalHeaders
 
         return sessionConfiguration


### PR DESCRIPTION
FFM-7275 - iOS SDK - SSE event stream doesn't time out when no data arrives

What
Fix SSE read timeout to 60 seconds instead of int max. Also fix user agent for SSE sockets.

Why
Manual testing of the iOS SDK has shown that the SSE event stream will not time out. This means if a network connection dies and becomes stale we won’t detect this and switch over to polling, which will cause the cache to get out of sync.

Testing
Manual testing with proxy to confirm polling is restarted, SSE is reconnected