### PR TITLE
FFM-8034 - iOS SDK Crash - defaultAPIManager being force unwrapped when nil

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,6 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.3"),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can also add the `ff-ios-client-sdk` dependency locally by dragging the SDK 
 
 ```Swift
 dependencies: [
-	.package(url: "https://github.com/harness/ff-ios-client-sdk.git", .upToNextMinor(from: "1.0.3"))
+	.package(url: "https://github.com/harness/ff-ios-client-sdk.git", .upToNextMinor(from: "1.0.4"))
 ]
 ```
 &nbsp;

--- a/Sources/ff-ios-client-sdk/Network/FeatureRepository.swift
+++ b/Sources/ff-ios-client-sdk/Network/FeatureRepository.swift
@@ -14,7 +14,7 @@ class FeatureRepository {
     var target: CfTarget
     var config: CfConfiguration
 	var storageSource: StorageRepositoryProtocol
-	var defaultAPIManager: DefaultAPIManagerProtocol!
+	var defaultAPIManager: DefaultAPIManagerProtocol?
 	
 	init(
         
@@ -46,7 +46,7 @@ class FeatureRepository {
         OpenAPIClientAPI.customHeaders = [CFHTTPHeaderField.authorization.rawValue:"Bearer \(self.token)"]
 		
 		Logger.log("Try to get ALL from CLOUD")
-		defaultAPIManager.getEvaluations(
+		defaultAPIManager?.getEvaluations(
             
             environmentUUID: self.config.environmentId,
             target: self.target.identifier,
@@ -106,7 +106,7 @@ class FeatureRepository {
 		}
 		OpenAPIClientAPI.customHeaders = [CFHTTPHeaderField.authorization.rawValue:"Bearer \(self.token)"]
 		Logger.log("Try to get Evaluation |\(evaluationId)| from CLOUD")
-		defaultAPIManager.getEvaluationByIdentifier(
+		defaultAPIManager?.getEvaluationByIdentifier(
             
             environmentUUID: self.config.environmentId,
             feature: evaluationId,

--- a/Sources/ff-ios-client-sdk/Version.swift
+++ b/Sources/ff-ios-client-sdk/Version.swift
@@ -2,5 +2,5 @@ import Foundation
 
 class Version {
     
-    static let version: String = "1.0.3"
+    static let version: String = "1.0.4"
 }

--- a/ff-ios-client-sdk.podspec
+++ b/ff-ios-client-sdk.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |ff|
 
   ff.name         = "ff-ios-client-sdk"
-  ff.version      = "1.0.3"
+  ff.version      = "1.0.4"
   ff.summary      = "iOS SDK for Harness Feature Flags Management"
 
   ff.description  = <<-DESC


### PR DESCRIPTION
FFM-8034 - iOS SDK Crash - defaultAPIManager being force unwrapped when nil

What
Fixes defaultAPIManager being force unwrapped causing a nil dereference. Instead change it to a regular optional and add nil checks

Why
If defaultAPIManager gets set to nil e.g. by destroy() or similar then it's possible to crash the SDK when evaluations are being retrieved

Testing
Manual testing against proxy and QA