### PR TITLE
FFM-8056 - Add support for variation methods that don't require a closure block

### DIFF
--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -276,14 +276,14 @@ public class CfClient {
 		self.fetchIfReady(evaluationId: evaluationId, defaultValue: defaultValue, completion)
 	}
 
-    public func stringVariation(evaluationId: String, defaultValue: String) -> String {
-        var result: String = defaultValue
-        self.stringVariation(evaluationId: evaluationId, defaultValue: defaultValue, { (eval) in
-            result = eval?.value.stringValue ?? defaultValue
-        })
+	public func stringVariation(evaluationId: String, defaultValue: String) -> String {
+		var result: String = defaultValue
+		self.stringVariation(evaluationId: evaluationId, defaultValue: defaultValue, { (eval) in
+			result = eval?.value.stringValue ?? defaultValue
+		})
 
-        return result;
-    }
+		return result;
+	}
 
     /**
 	Fetch `Bool` `Evaluation` from cache.
@@ -300,23 +300,23 @@ public class CfClient {
 		self.fetchIfReady(evaluationId: evaluationId, defaultValue: defaultValue, completion)
 	}
 	
-    /**
-    Fetch a boolean flag from cache. This method returns a `Bool` value directly and does not require a closure.
-    Make sure to call [intialize](x-source-tag://initialize) prior to calling this method.
-    If called prior to calling [intialize](x-source-tag://initialize), `defaultValue` will be returned or `nil`, if `defaultValue` was not specified.
-    - Parameters:
-       - evaluationId: ID of the `Evaluation` you want to fetch.
-       - defaultValue: Value to be returned if no such `Evaluation` exists in the cache.
-       - result: `Bool`
-    */
-    public func boolVariation(evaluationId: String, defaultValue: Bool) -> Bool {
-        var result: Bool = defaultValue
-        self.boolVariation(evaluationId: evaluationId, defaultValue: defaultValue, { (eval) in
-            result = eval?.value.boolValue ?? defaultValue
-        })
+	/**
+	Fetch a boolean flag from cache. This method returns a `Bool` value directly and does not require a closure.
+	Make sure to call [intialize](x-source-tag://initialize) prior to calling this method.
+	If called prior to calling [intialize](x-source-tag://initialize), `defaultValue` will be returned or `nil`, if `defaultValue` was not specified.
+	- Parameters:
+	   - evaluationId: ID of the `Evaluation` you want to fetch.
+	   - defaultValue: Value to be returned if no such `Evaluation` exists in the cache.
+	   - result: `Bool`
+	*/
+	public func boolVariation(evaluationId: String, defaultValue: Bool) -> Bool {
+		var result: Bool = defaultValue
+		self.boolVariation(evaluationId: evaluationId, defaultValue: defaultValue, { (eval) in
+			result = eval?.value.boolValue ?? defaultValue
+		})
 
-        return result;
-    }
+		return result;
+	}
 
 	/**
 	Fetch `Number` `Evaluation` from cache.
@@ -333,23 +333,23 @@ public class CfClient {
 		self.fetchIfReady(evaluationId: evaluationId, defaultValue: defaultValue, completion)
 	}
 	
-    /**
-    Fetch a number flag from cache. This method returns a `Int` value directly and does not require a closure.
-    Make sure to call [intialize](x-source-tag://initialize) prior to calling this method.
-    If called prior to calling [intialize](x-source-tag://initialize), `defaultValue` will be returned or `nil`, if `defaultValue` was not specified.
-    - Parameters:
-       - evaluationId: ID of the `Evaluation` you want to fetch.
-       - defaultValue: Value to be returned if no such `Evaluation` exists in the cache.
-       - result: `Int`
-    */
-    public func numberVariation(evaluationId: String, defaultValue: Int) -> Int {
-        var result: Int = defaultValue
-        self.numberVariation(evaluationId: evaluationId, defaultValue: defaultValue, { (eval) in
-            result = eval?.value.intValue ?? defaultValue
-        })
+	/**
+	Fetch a number flag from cache. This method returns a `Int` value directly and does not require a closure.
+	Make sure to call [intialize](x-source-tag://initialize) prior to calling this method.
+	If called prior to calling [intialize](x-source-tag://initialize), `defaultValue` will be returned or `nil`, if `defaultValue` was not specified.
+	- Parameters:
+	   - evaluationId: ID of the `Evaluation` you want to fetch.
+	   - defaultValue: Value to be returned if no such `Evaluation` exists in the cache.
+	   - result: `Int`
+	*/
+	public func numberVariation(evaluationId: String, defaultValue: Int) -> Int {
+		var result: Int = defaultValue
+		self.numberVariation(evaluationId: evaluationId, defaultValue: defaultValue, { (eval) in
+			result = eval?.value.intValue ?? defaultValue
+		})
 
-        return result;
-    }
+		return result;
+	}
 
 	/**
 	Fetch `[String:ValueType]` `Evaluation` from cache.
@@ -372,22 +372,22 @@ public class CfClient {
 		self.fetchIfReady(evaluationId: evaluationId, defaultValue: defaultValue, completion)
 	}
 
-    /**
-    Fetch JSON flag from cache. This method returns a string value directly and does not require a closure. Also the JSON is returned as a string.
-    Make sure to call [intialize](x-source-tag://initialize) prior to calling this method.
-    If called prior to calling [intialize](x-source-tag://initialize), `defaultValue` will be returned or `nil`, if `defaultValue` was not specified.
-     - Parameters:
-         - evaluationId: ID of the `Evaluation` you want to fetch.
-        - defaultValue: Default JSON string to be returned if no such `Evaluation` exists in the cache.
-        - result: JSON string
-    */
-    public func jsonVariation(evaluationId: String, defaultValue: String) -> String {
-        var result: String = defaultValue
-        self.jsonVariation(evaluationId: evaluationId, defaultValue: nil, { (eval) in
-            result = eval?.value.stringValue ?? defaultValue
-        })
-        return result;
-    }
+	/**
+	Fetch JSON flag from cache. This method returns a string value directly and does not require a closure. Also the JSON is returned as a string.
+	Make sure to call [intialize](x-source-tag://initialize) prior to calling this method.
+	If called prior to calling [intialize](x-source-tag://initialize), `defaultValue` will be returned or `nil`, if `defaultValue` was not specified.
+	 - Parameters:
+	     - evaluationId: ID of the `Evaluation` you want to fetch.
+	    - defaultValue: Default JSON string to be returned if no such `Evaluation` exists in the cache.
+	    - result: JSON string
+	*/
+	public func jsonVariation(evaluationId: String, defaultValue: String) -> String {
+	    var result: String = defaultValue
+	    self.jsonVariation(evaluationId: evaluationId, defaultValue: nil, { (eval) in
+	        result = eval?.value.stringValue ?? defaultValue
+	    })
+	    return result;
+	}
 
 	/**
 	 Clears the occupied resources and shuts down the sdk.

--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -275,8 +275,17 @@ public class CfClient {
 	public func stringVariation(evaluationId: String, defaultValue: String? = nil, _ completion:@escaping(_ result:Evaluation?)->()) {
 		self.fetchIfReady(evaluationId: evaluationId, defaultValue: defaultValue, completion)
 	}
-	
-	/**
+
+    public func stringVariation(evaluationId: String, defaultValue: String) -> String {
+        var result: String = defaultValue
+        self.stringVariation(evaluationId: evaluationId, defaultValue: defaultValue, { (eval) in
+            result = eval?.value.stringValue ?? defaultValue
+        })
+
+        return result;
+    }
+
+    /**
 	Fetch `Bool` `Evaluation` from cache.
 	Make sure to call [intialize](x-source-tag://initialize) prior to calling this method.
 	If called prior to calling [intialize](x-source-tag://initialize), `defaultValue` will be returned or `nil`, if `defaultValue` was not specified.
@@ -291,6 +300,24 @@ public class CfClient {
 		self.fetchIfReady(evaluationId: evaluationId, defaultValue: defaultValue, completion)
 	}
 	
+    /**
+    Fetch a boolean flag from cache. This method returns a `Bool` value directly and does not require a closure.
+    Make sure to call [intialize](x-source-tag://initialize) prior to calling this method.
+    If called prior to calling [intialize](x-source-tag://initialize), `defaultValue` will be returned or `nil`, if `defaultValue` was not specified.
+    - Parameters:
+       - evaluationId: ID of the `Evaluation` you want to fetch.
+       - defaultValue: Value to be returned if no such `Evaluation` exists in the cache.
+       - result: `Bool`
+    */
+    public func boolVariation(evaluationId: String, defaultValue: Bool) -> Bool {
+        var result: Bool = defaultValue
+        self.boolVariation(evaluationId: evaluationId, defaultValue: defaultValue, { (eval) in
+            result = eval?.value.boolValue ?? defaultValue
+        })
+
+        return result;
+    }
+
 	/**
 	Fetch `Number` `Evaluation` from cache.
 	Make sure to call [intialize](x-source-tag://initialize) prior to calling this method.
@@ -306,6 +333,24 @@ public class CfClient {
 		self.fetchIfReady(evaluationId: evaluationId, defaultValue: defaultValue, completion)
 	}
 	
+    /**
+    Fetch a number flag from cache. This method returns a `Int` value directly and does not require a closure.
+    Make sure to call [intialize](x-source-tag://initialize) prior to calling this method.
+    If called prior to calling [intialize](x-source-tag://initialize), `defaultValue` will be returned or `nil`, if `defaultValue` was not specified.
+    - Parameters:
+       - evaluationId: ID of the `Evaluation` you want to fetch.
+       - defaultValue: Value to be returned if no such `Evaluation` exists in the cache.
+       - result: `Int`
+    */
+    public func numberVariation(evaluationId: String, defaultValue: Int) -> Int {
+        var result: Int = defaultValue
+        self.numberVariation(evaluationId: evaluationId, defaultValue: defaultValue, { (eval) in
+            result = eval?.value.intValue ?? defaultValue
+        })
+
+        return result;
+    }
+
 	/**
 	Fetch `[String:ValueType]` `Evaluation` from cache.
 	Make sure to call [intialize](x-source-tag://initialize) prior to calling this method.
@@ -326,7 +371,24 @@ public class CfClient {
 	public func jsonVariation(evaluationId: String, defaultValue:[String:ValueType]? = nil, _ completion:@escaping(_ result: Evaluation?)->()) {
 		self.fetchIfReady(evaluationId: evaluationId, defaultValue: defaultValue, completion)
 	}
-	
+
+    /**
+    Fetch JSON flag from cache. This method returns a string value directly and does not require a closure. Also the JSON is returned as a string.
+    Make sure to call [intialize](x-source-tag://initialize) prior to calling this method.
+    If called prior to calling [intialize](x-source-tag://initialize), `defaultValue` will be returned or `nil`, if `defaultValue` was not specified.
+     - Parameters:
+         - evaluationId: ID of the `Evaluation` you want to fetch.
+        - defaultValue: Default JSON string to be returned if no such `Evaluation` exists in the cache.
+        - result: JSON string
+    */
+    public func jsonVariation(evaluationId: String, defaultValue: String) -> String {
+        var result: String = defaultValue
+        self.jsonVariation(evaluationId: evaluationId, defaultValue: nil, { (eval) in
+            result = eval?.value.stringValue ?? defaultValue
+        })
+        return result;
+    }
+
 	/**
 	 Clears the occupied resources and shuts down the sdk.
 	 After calling this method, the [intialize](x-source-tag://initialize) must be called again. It will also


### PR DESCRIPTION
FFM-8056 - Add support for variation methods that don't require a closure block

What
Add some new methods to CfClient to allow flags to be queried directly

Why
This makes the iOS API consistent with the Android SDK

Testing
Manual + demo project