### PR TITLE
(FFM-7956) Add pre-evaluation support

### DIFF
--- a/Sources/ff-ios-client-sdk/Models/CfModels.swift
+++ b/Sources/ff-ios-client-sdk/Models/CfModels.swift
@@ -12,5 +12,6 @@ public struct Message: Codable {
 	public var domain: String?
 	public var identifier: String?
 	public var version: Double?
+	public var evaluation: Evaluation?
 }
 

--- a/Sources/ff-ios-client-sdk/Network/FeatureRepository.swift
+++ b/Sources/ff-ios-client-sdk/Network/FeatureRepository.swift
@@ -144,6 +144,27 @@ class FeatureRepository {
 		}
 	}
     
+    /// Use this method to save an `Evaluation`
+    /// - Parameters:
+    ///   - evaluation: the evaluation to save to storage
+    ///   - onCompletion: completion block containing `Evaluation?` or `CFError?` from appropriate lower level methods.
+    func saveEvaluation(
+        evaluation: Evaluation,
+        onCompletion:@escaping(Result<Evaluation, CFError>)->()
+    ) {
+        let key = CfConstants.Persistance.feature(self.config.environmentId, self.target.identifier, evaluation.flag).value
+        do {
+            try self.storageSource.saveValue(evaluation, key: key)
+            self.updateAll(evaluation)
+            Logger.log("SUCCESS: Saved |\(evaluation.flag)| -> |\(evaluation.value)| from SSE event")
+            onCompletion(.success(evaluation))
+        } catch {
+            Logger.log("Failed saving |\(evaluation.flag)| to cache")
+            onCompletion(.failure(CFError.storageError))
+        }
+        
+    }
+    
 	private func updateAll(_ eval: Evaluation) {
 		let allKey = CfConstants.Persistance.features(self.config.environmentId, self.target.identifier).value
 		do {


### PR DESCRIPTION
**Changes**
If the flag evaluation is sent directly in the sse stream save it and don't query SaaS.
If the flag evaluation isn't sent then query SaaS for the updated value as normal.

**Demo**

https://github.com/harness/ff-ios-client-sdk/assets/42169772/b7784abb-d397-44d4-a62a-52c104d900fc

