### PR TITLE
FFM-8162 - iOS SDK - Fix unit tests

### DIFF
--- a/Tests/ff-ios-client-sdkTests/Mocks/CFProjectMocks.swift
+++ b/Tests/ff-ios-client-sdkTests/Mocks/CFProjectMocks.swift
@@ -14,6 +14,7 @@ struct CfProjectMocks {
         dict["environmentIdentifier"]   = "environmentIdentifier_value"
         dict["environment"]             = "environment_value"
         dict["accountID"]               = "accountID_value"
+        dict["clusterIdentifier"]       = "clusterIdentifier_value"
         return dict
     }
 }

--- a/Tests/ff-ios-client-sdkTests/Mocks/CacheMocks.swift
+++ b/Tests/ff-ios-client-sdkTests/Mocks/CacheMocks.swift
@@ -55,15 +55,15 @@ struct CacheMocks {
 		for _ in 0..<count  {
 			if let type = type {
 				switch type {
-					case .string(let stringVal): mocks.append(.init(flag: TestFlagValue(.string).key, value: ValueType.string(stringVal)))
-					case .bool(let boolVal): mocks.append(.init(flag: TestFlagValue(.bool).key, value: ValueType.bool(boolVal)))
-					case .int(let intVal): mocks.append(.init(flag: TestFlagValue(.int).key, value: ValueType.int(intVal)))
-					case .object(let objectVal): mocks.append(.init(flag: TestFlagValue(.object).key, value: ValueType.object(objectVal)))
+					case .string(let stringVal): mocks.append(.init(flag: TestFlagValue(.string).key, identifier: "test", value: ValueType.string(stringVal)))
+					case .bool(let boolVal): mocks.append(.init(flag: TestFlagValue(.bool).key, identifier: "test", value: ValueType.bool(boolVal)))
+					case .int(let intVal): mocks.append(.init(flag: TestFlagValue(.int).key, identifier: "test", value: ValueType.int(intVal)))
+					case .object(let objectVal): mocks.append(.init(flag: TestFlagValue(.object).key, identifier: "test", value: ValueType.object(objectVal)))
 				}
 			} else {
 				let random = Int(arc4random_uniform(UInt32(TestFlagValue.RawValue.allCases.count)))
 				let randomValueType = TestFlagValue(TestFlagValue.RawValue(rawValue: random)!)
-				mocks.append(.init(flag: randomValueType.key, value: randomValueType.value))
+                mocks.append(.init(flag: randomValueType.key, identifier: "test", value: randomValueType.value))
 			}
 		}
         return mocks
@@ -85,7 +85,7 @@ struct CacheMocks {
 			let random = Int(arc4random_uniform(UInt32(TestFlagValue.RawValue.allCases.count)))
 			let randomValueType = TestFlagValue(TestFlagValue.RawValue(rawValue: random)!)
 			if !mocks.contains(where: {$0.value == randomValueType.value}) {
-				mocks.append(.init(flag: randomValueType.key, value: randomValueType.value))
+                mocks.append(.init(flag: randomValueType.key, identifier: "test", value: randomValueType.value))
 			}
 		}
 		return mocks

--- a/Tests/ff-ios-client-sdkTests/Mocks/DefaultAPIManagerMock.swift
+++ b/Tests/ff-ios-client-sdkTests/Mocks/DefaultAPIManagerMock.swift
@@ -9,8 +9,9 @@ import Foundation
 @testable import ff_ios_client_sdk
 
 class DefaultAPIManagerMock: DefaultAPIManagerProtocol {
+    
 	var replacementEnabled = false
-	func getEvaluations(environmentUUID: String, target: String, apiResponseQueue: DispatchQueue, completion: @escaping (Swift.Result<[Evaluation], ff_ios_client_sdk.CFError>) -> ()) {
+	func getEvaluations(environmentUUID: String, target: String, cluster: String, apiResponseQueue: DispatchQueue, completion: @escaping (Swift.Result<[Evaluation], ff_ios_client_sdk.CFError>) -> ()) {
 		if target == "success" {
 			let evaluations = CacheMocks.createAllTypeFlagMocks()
 			completion(.success(evaluations))
@@ -19,7 +20,7 @@ class DefaultAPIManagerMock: DefaultAPIManagerProtocol {
 		}
 	}
 	
-	func getEvaluationByIdentifier(environmentUUID: String, feature: String, target: String, apiResponseQueue: DispatchQueue, completion: @escaping (Swift.Result<Evaluation, ff_ios_client_sdk.CFError>) -> ()) {
+	func getEvaluationByIdentifier(environmentUUID: String, feature: String, target: String, cluster: String, apiResponseQueue: DispatchQueue, completion: @escaping (Swift.Result<Evaluation, ff_ios_client_sdk.CFError>) -> ()) {
 		var found = false
  		if target == "cloud_failure_cache_failure" {
 			completion(.failure(CFError.storageError))
@@ -29,10 +30,10 @@ class DefaultAPIManagerMock: DefaultAPIManagerProtocol {
 				var modifiedEval: Evaluation?
 				let value = evaluation.value
 				switch value {
-					case .string(let string): modifiedEval = Evaluation(flag: evaluation.flag, value: .string(string + "_changed"))
-					case .bool(let bool):  modifiedEval = Evaluation(flag: evaluation.flag, value: .bool(!bool))
-					case .int(let int): modifiedEval = Evaluation(flag: evaluation.flag, value: .int(int + 5))
-					case .object(_): modifiedEval = Evaluation(flag: evaluation.flag, value: .object(["added":ValueType.bool(true)]))
+					case .string(let string): modifiedEval = Evaluation(flag: evaluation.flag, identifier: "test", value: .string(string + "_changed"))
+					case .bool(let bool):  modifiedEval = Evaluation(flag: evaluation.flag, identifier: "test",value: .bool(!bool))
+					case .int(let int): modifiedEval = Evaluation(flag: evaluation.flag, identifier: "test",value: .int(int + 5))
+					case .object(_): modifiedEval = Evaluation(flag: evaluation.flag, identifier: "test", value: .object(["added":ValueType.bool(true)]))
 				}
 				completion(.success(modifiedEval!))
 			} else {

--- a/Tests/ff-ios-client-sdkTests/Mocks/JWTMocks.swift
+++ b/Tests/ff-ios-client-sdkTests/Mocks/JWTMocks.swift
@@ -9,8 +9,10 @@ struct JWTMocks {
     static let stringMock = """
             eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
             """
-	static let token =
-		"""
-		"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwcm9qZWN0IjoiZTRkZWIxMDYtODU1MC00OTBhLWIyZWMtNmZhZDQzNTdiZmMyIiwiZW52aXJvbm1lbnQiOiJjMzRmYjhiOS05NDc5LTRlMTMtYjRjYy1kNDNjOGY2YjFhNWQiLCJwcm9qZWN0SWRlbnRpZmllciI6ImZlYXR1cmVmbGFnIiwiZW52aXJvbm1lbnRJZGVudGlmaWVyIjoicHJvZHVjdGlvbiIsImFjY291bnRJRCI6InpFYWFrLUZMUzQyNUlFTzdPTHpNVWciLCJvcmdhbml6YXRpb24iOiI1MDc5ZTNkOS03NDg2LTQwNmYtYTJjYi0wODM2YWVlYzRhMTgifQ.uSN83JSNOV27g6Dfx5DUpStyvnYflLKjtGAw1sIgrSE"
-		"""
+    
+    static let token =
+        """
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwcm9qZWN0IjoiZTRkZWIxMDYtODU1MC00OTBhLWIyZWMtNmZhZDQzNTdiZmMyIiwiZW52aXJvbm1lbnQiOiJjMzRmYjhiOS05NDc5LTRlMTMtYjRjYy1kNDNjOGY2YjFhNWQiLCJwcm9qZWN0SWRlbnRpZmllciI6ImZlYXR1cmVmbGFnIiwiZW52aXJvbm1lbnRJZGVudGlmaWVyIjoicHJvZHVjdGlvbiIsImFjY291bnRJRCI6InpFYWFrLUZMUzQyNUlFTzdPTHpNVWciLCJvcmdhbml6YXRpb24iOiI1MDc5ZTNkOS03NDg2LTQwNmYtYTJjYi0wODM2YWVlYzRhMTgiLCJjbHVzdGVySWRlbnRpZmllciI6IjEifQ.KX3PeY9cHbtb8txqb2XE3uHHQ3zW2i_vNgh1-ir4eVw"
+        """
+
 }

--- a/Tests/ff-ios-client-sdkTests/TestCases/CFAPI/AuthenticationRequestTest.swift
+++ b/Tests/ff-ios-client-sdkTests/TestCases/CFAPI/AuthenticationRequestTest.swift
@@ -23,7 +23,7 @@ class AuthenticationRequestTest: XCTestCase {
 		let config = CfConfiguration.builder().build()
 		let target = CfTarget.builder().build()
 		
-		let repository = FeatureRepository(token: "someToken", storageSource: mockCache, config: config, target: target, defaultAPIManager: mockAPIManager)
+        let repository = FeatureRepository(token: "someToken", cluster: "1", storageSource: mockCache, config: config, target: target, defaultAPIManager: mockAPIManager)
 		cfClient.featureRepository = repository
 	}
 	

--- a/Tests/ff-ios-client-sdkTests/TestCases/CFAPI/FeatureRepositoryTest.swift
+++ b/Tests/ff-ios-client-sdkTests/TestCases/CFAPI/FeatureRepositoryTest.swift
@@ -66,10 +66,13 @@ class FeatureRepositoryTest: XCTestCase {
 		// When
         sut!.getEvaluations(onCompletion:) { result in
             // Then
-            XCTAssertNil(result)
+            switch result {
+            case .failure(let error):
+                XCTAssertTrue(error.errorData.title == "Storage Error")
+            case .success(_):
+                XCTFail("should not be success")
+            }
         }
-		
-
 	}
 	
 	func testGetEvaluationByIdSuccessReplaceSuccess() {

--- a/Tests/ff-ios-client-sdkTests/TestCases/CFAPI/FeatureRepositoryTest.swift
+++ b/Tests/ff-ios-client-sdkTests/TestCases/CFAPI/FeatureRepositoryTest.swift
@@ -18,7 +18,7 @@ class FeatureRepositoryTest: XCTestCase {
 		var config = CfConfiguration.builder().build()
 		config.environmentId = "c34fb8b9-9479-4e13-b4cc-d43c8f6b1a5d"
 		let target = CfTarget.builder().build()
-		sut = FeatureRepository(token: nil, storageSource: mockCache, config: config, target: target)
+        sut = FeatureRepository(token: nil, cluster: "1", storageSource: mockCache, config: config, target: target)
 		sut!.defaultAPIManager = DefaultAPIManagerMock()
 		expectation = XCTestExpectation(description: #function)
     }
@@ -35,7 +35,7 @@ class FeatureRepositoryTest: XCTestCase {
 		let target = CfTarget.builder().setIdentifier("testID").build()
 		
 		// When
-		let defaultRepo = FeatureRepository(token: token, storageSource: mockCache, config: config, target: target)
+        let defaultRepo = FeatureRepository(token: token, cluster: "1", storageSource: mockCache, config: config, target: target)
 		
 		// Then
 		XCTAssertEqual(defaultRepo.token, token)
@@ -52,11 +52,11 @@ class FeatureRepositoryTest: XCTestCase {
 		sut?.target.identifier = "success"
 		
 		// When
-		let result = await(sut!.getEvaluations(onCompletion:))
-		
-		// Then
-		XCTAssertNotNil(result)
-		XCTAssertEqual(result?.count, 4, "Expected count == 4")
+        sut!.getEvaluations(onCompletion:) { result in
+            // Then
+            XCTAssertNotNil(result)
+            XCTAssertEqual(try? result.get().count, 4, "Expected count == 4")
+        }
     }
 	
 	func testGetEvaluationFailure() {
@@ -64,10 +64,12 @@ class FeatureRepositoryTest: XCTestCase {
 		sut?.target.identifier = "failure"
 		
 		// When
-		let result = await(sut!.getEvaluations(onCompletion:))
+        sut!.getEvaluations(onCompletion:) { result in
+            // Then
+            XCTAssertNil(result)
+        }
 		
-		// Then
-		XCTAssertNil(result)
+
 	}
 	
 	func testGetEvaluationByIdSuccessReplaceSuccess() {

--- a/Tests/ff-ios-client-sdkTests/TestCases/CFAPI/RegisterForEventsTest.swift
+++ b/Tests/ff-ios-client-sdkTests/TestCases/CFAPI/RegisterForEventsTest.swift
@@ -23,7 +23,7 @@ class RegisterForEventsTest: XCTestCase {
 		let target = CfTarget.builder().build()
 		
 		let defaultAPIManager = DefaultAPIManagerMock()
-		let repository = FeatureRepository(token: "someToken", storageSource: mockCache, config: config, target: target, defaultAPIManager: defaultAPIManager)
+        let repository = FeatureRepository(token: "someToken", cluster: "1", storageSource: mockCache, config: config, target: target, defaultAPIManager: defaultAPIManager)
 
 		cfClient.featureRepository = repository
 		cfClient.configuration = config
@@ -89,7 +89,7 @@ class RegisterForEventsTest: XCTestCase {
 		// Given
 		let exp = XCTestExpectation(description: #function)
 		var config = CfConfiguration.builder().setStreamEnabled(true).build()
-		let eval = Evaluation(flag: "testRegisterEventSuccessFlag", value: .bool(true))
+        let eval = Evaluation(flag: "testRegisterEventSuccessFlag", identifier: "test", value: .bool(true))
 		try? cfClient.featureRepository.storageSource.saveValue(eval, key: "SODOD")
 		config.environmentId = "successID"
 		cfClient.configuration = config

--- a/Tests/ff-ios-client-sdkTests/TestCases/Models/EvaluationTest.swift
+++ b/Tests/ff-ios-client-sdkTests/TestCases/Models/EvaluationTest.swift
@@ -26,7 +26,7 @@ class EvaluationTest: XCTestCase {
 		let value = ValueType.string("test-value")
         
 		// When
-        let evaluation = Evaluation(flag: flag, value: value)
+        let evaluation = Evaluation(flag: flag, identifier: "test", value: value)
         
 		// Then
 		XCTAssertEqual(evaluation.flag == flag, evaluation.value.stringValue == value.stringValue)
@@ -41,7 +41,7 @@ class EvaluationTest: XCTestCase {
 		let value = ValueType.string("30")
 		
 		// When
-		let evaluation = Evaluation(flag: flag, value: value)
+		let evaluation = Evaluation(flag: flag, identifier: "test", value: value)
 		
 		// Then
 		XCTAssertEqual(evaluation.flag == flag, evaluation.value.stringValue == value.stringValue)
@@ -56,7 +56,7 @@ class EvaluationTest: XCTestCase {
 		let value = ValueType.string("true")
 		
 		// When
-		let evaluation = Evaluation(flag: flag, value: value)
+		let evaluation = Evaluation(flag: flag, identifier: "test", value: value)
 		
 		// Then
 		XCTAssertEqual(evaluation.flag == flag, evaluation.value.stringValue == value.stringValue)
@@ -71,7 +71,7 @@ class EvaluationTest: XCTestCase {
 		let value = ValueType.string("false")
 		
 		// When
-		let evaluation = Evaluation(flag: flag, value: value)
+		let evaluation = Evaluation(flag: flag, identifier: "test", value: value)
 		
 		// Then
 		XCTAssertEqual(evaluation.flag == flag, evaluation.value.stringValue == value.stringValue)
@@ -86,7 +86,7 @@ class EvaluationTest: XCTestCase {
 		let value = ValueType.string("{key:value}")
 		
 		// When
-		let evaluation = Evaluation(flag: flag, value: value)
+		let evaluation = Evaluation(flag: flag, identifier: "test", value: value)
 		
 		// Then
 		XCTAssertEqual(evaluation.flag == flag, evaluation.value.stringValue == value.stringValue)
@@ -102,7 +102,7 @@ class EvaluationTest: XCTestCase {
 		let value = ValueType.int(1)
 		
 		// When
-		let evaluation = Evaluation(flag: flag, value: value)
+		let evaluation = Evaluation(flag: flag, identifier: "test", value: value)
 		
 		// Then
 		XCTAssertEqual(evaluation.flag == flag, evaluation.value.intValue == value.intValue)
@@ -117,7 +117,7 @@ class EvaluationTest: XCTestCase {
 		let value = ValueType.int(0)
 		
 		// When
-		let evaluation = Evaluation(flag: flag, value: value)
+		let evaluation = Evaluation(flag: flag, identifier: "test", value: value)
 		
 		// Then
 		XCTAssertEqual(evaluation.flag == flag, evaluation.value.intValue == value.intValue)
@@ -132,7 +132,7 @@ class EvaluationTest: XCTestCase {
 		let value = ValueType.bool(true)
 		
 		// When
-		let evaluation = Evaluation(flag: flag, value: value)
+		let evaluation = Evaluation(flag: flag, identifier: "test", value: value)
 		
 		// Then
 		XCTAssertEqual(evaluation.flag == flag, evaluation.value.boolValue == value.boolValue)
@@ -147,7 +147,7 @@ class EvaluationTest: XCTestCase {
 		let value = ValueType.bool(false)
 		
 		// When
-		let evaluation = Evaluation(flag: flag, value: value)
+		let evaluation = Evaluation(flag: flag, identifier: "test", value: value)
 		
 		// Then
 		XCTAssertEqual(evaluation.flag == flag, evaluation.value.boolValue == value.boolValue)
@@ -162,7 +162,7 @@ class EvaluationTest: XCTestCase {
 		let value = ValueType.int(5)
 		
 		// When
-		let evaluation = Evaluation(flag: flag, value: value)
+		let evaluation = Evaluation(flag: flag, identifier: "test", value: value)
 		
 		// Then
 		XCTAssertEqual(evaluation.flag == flag, evaluation.value.intValue == value.intValue)
@@ -177,7 +177,7 @@ class EvaluationTest: XCTestCase {
 		let value = ValueType.object(ValueType.Value(dictionaryLiteral: ("testKey", .string("testValue"))))
 		
 		// Then
-		let evaluation = Evaluation(flag: flag, value: value)
+		let evaluation = Evaluation(flag: flag, identifier: "test", value: value)
 		
 		// Then
 		XCTAssertEqual(evaluation.flag == flag, evaluation.value.objectValue == value.objectValue)


### PR DESCRIPTION
FFM-8162 - iOS SDK - Fix unit tests

What
Some of the unit tests don't work because they have become out of date. Update tests so we can enabled them on CI.

Testing
Tested in xcode and xcodebuild