### PR TITLE
(FFM-8174) Add group event callback

### DIFF
--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -711,6 +711,7 @@ public class CfClient {
                                         case .success(let evaluations):
                                             do {
                                                 try self.storageSource?.saveValue(evaluations, key: allKey)
+                                                onEvent(EventType.onPolling(evaluations), nil)
                                             } catch {
                                                 //If saving to cache fails, pass success for authorization and continue
                                                 print("Could not save to cache")


### PR DESCRIPTION
**Issue**
When flags change e.g. after polling [here](https://github.com/harness/ff-ios-client-sdk/blob/ddd59670bd3ec001a9d9440a60a3f8577f73fad3/Sources/ff-ios-client-sdk/CfClient.swift#L779) or after flag events [here](https://github.com/harness/ff-ios-client-sdk/blob/ddd59670bd3ec001a9d9440a60a3f8577f73fad3/Sources/ff-ios-client-sdk/CfClient.swift#L727) we return events so customers can update their apps UI’s accordingly. However when we receive a target group event we don’t currently return any event. In our sample app this means the app doesn’t actually re-render to display the new values.

**Fix**
Return an OnPolling event to show all flags have been fetched after we save the flags here and return their values.


