### PR TITLE
FFM-8048 - Add HTTP headers for diagnostics

### DIFF
--- a/Sources/ff-ios-client-sdk/Network/EventSourceManager.swift
+++ b/Sources/ff-ios-client-sdk/Network/EventSourceManager.swift
@@ -45,7 +45,7 @@ class EventSourceManager: EventSourceManagerProtocol {
             let config = self.configuration!
             let cluster = parameterConfig?.cluster ?? ""
 			let streamUrl = URL(string: "\(config.streamUrl)?cluster=\(cluster)")!
-            let headers = parameterConfig?.authHeader ?? [:]
+            let headers = parameterConfig?.headers ?? [:]
 			    
             NSLog("Api, streamUrl: \(streamUrl)")
             
@@ -121,6 +121,6 @@ class EventSourceManager: EventSourceManagerProtocol {
 
 struct ParameterConfig {
 	
-    let authHeader: [String:String]
+    let headers: [String:String]
     let cluster: String
 }

--- a/Sources/ff-ios-client-sdk/Network/FeatureRepository.swift
+++ b/Sources/ff-ios-client-sdk/Network/FeatureRepository.swift
@@ -42,9 +42,6 @@ class FeatureRepository {
         
         onCompletion:@escaping(Result<[Evaluation], CFError>)->()
     ) {
-		
-        OpenAPIClientAPI.customHeaders = [CFHTTPHeaderField.authorization.rawValue:"Bearer \(self.token)"]
-		
 		Logger.log("Try to get ALL from CLOUD")
 		defaultAPIManager?.getEvaluations(
             
@@ -104,7 +101,7 @@ class FeatureRepository {
 			}
 			return
 		}
-		OpenAPIClientAPI.customHeaders = [CFHTTPHeaderField.authorization.rawValue:"Bearer \(self.token)"]
+
 		Logger.log("Try to get Evaluation |\(evaluationId)| from CLOUD")
 		defaultAPIManager?.getEvaluationByIdentifier(
             


### PR DESCRIPTION
FFM-8048 - Add HTTP headers for diagnostics

What
Add Harness-SDK-Info, Harness-EnvironmentID and Harness-AccountID HTTP headers to outbound HTTP connections

Why
Helps with diagnosing issues on the backend

Testing
Manual - tested with a proxy that logs headers