### PR TITLE
FFM-7015 - iOS SDK - TLS - support custom CAs

### DIFF
--- a/Sources/ff-ios-client-sdk/Builders/CfConfigurationBuilder.swift
+++ b/Sources/ff-ios-client-sdk/Builders/CfConfigurationBuilder.swift
@@ -22,7 +22,8 @@ public class CfConfigurationBuilder {
             streamEnabled: false,
             analyticsEnabled: true,
             pollingInterval: minimumPollingInterval,
-            environmentId: ""
+            environmentId: "",
+            tlsTrustedCAs: []
         )
 	}
 	/**
@@ -84,6 +85,16 @@ public class CfConfigurationBuilder {
 		config.pollingInterval = interval < minimumPollingInterval ? minimumPollingInterval : interval
 		return self
 	}
+    /**
+    Adds `TlsTrustedCAs`  to CfConfiguration
+    - Parameter tlsTrustedCAs: Array of trusted Certificate Authority X.509 certificates (in PEM format) that will be used when connecting to the config, stream and event endpoints, you should include any intermediate CAs.
+    - Note: `build()` needs to be called as the final method in the chain
+    */
+    public func setTlsTrustedCAs(_ tlsTrustedCAs:[String]) -> CfConfigurationBuilder {
+        config.tlsTrustedCAs = tlsTrustedCAs
+        return self
+    }
+    
 	/**
 	Builds CfConfiguration object by providing components or is set to default component/s.
 	- `setConfigUrl(_:)`

--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -183,7 +183,13 @@ public class CfClient {
 		self.apiKey = apiKey
 		self.target = target
 		
+        if (!configuration.tlsTrustedCAs.isEmpty) {
+            SdkTls.setPems(pems: configuration.tlsTrustedCAs)
+            OpenAPIClientAPI.requestBuilderFactory = TlsURLSessionRequestBuilderFactory()
+        }
+
         OpenAPIClientAPI.configPath = configuration.configUrl
+        OpenAPIClientAPI.eventPath = configuration.eventUrl
 		
         let authRequest = AuthenticationRequest(apiKey: apiKey, target: target)
 		self.authenticate(authRequest, cache: cache) { (response) in

--- a/Sources/ff-ios-client-sdk/CfConfiguration.swift
+++ b/Sources/ff-ios-client-sdk/CfConfiguration.swift
@@ -20,6 +20,7 @@ public struct CfConfiguration {
 	var pollingInterval: TimeInterval
 	var environmentId: String
     var analyticsFrequency: Int
+    var tlsTrustedCAs: [String]
 	
 	internal init(
         
@@ -29,7 +30,8 @@ public struct CfConfiguration {
         streamEnabled: Bool,
         analyticsEnabled: Bool,
         pollingInterval:TimeInterval,
-        environmentId: String
+        environmentId: String,
+        tlsTrustedCAs: [String]
         
     ) {
 		
@@ -41,6 +43,7 @@ public struct CfConfiguration {
 		self.pollingInterval = pollingInterval
 		self.environmentId = environmentId
         self.analyticsFrequency = CfConfiguration.MIN_ANALYTICS_FREQUENCY
+        self.tlsTrustedCAs = tlsTrustedCAs
 	}
 	
 	public static func builder() -> CfConfigurationBuilder {

--- a/Sources/ff-ios-client-sdk/Common/SdkTls.swift
+++ b/Sources/ff-ios-client-sdk/Common/SdkTls.swift
@@ -1,0 +1,148 @@
+//
+//  SdkTls.swift
+//  
+//
+//  Created by Andrew Bell on 08/06/2023.
+//
+
+import Foundation
+import Security
+
+class SdkTls {
+
+    private static var pemArray:[String] = []
+
+    public static func setPems(pems:[String]) {
+        pemArray = pems
+    }
+
+    public static func isTlsEnabled() -> Bool {
+        return !pemArray.isEmpty
+    }
+
+    public static var trustedCerts: [SecCertificate] {
+        var certs = Array<SecCertificate>()
+        for pem in pemArray {
+            if let certData = Data(base64Encoded: stripPem(pem: pem)) {
+                certs.append(SecCertificateCreateWithData(nil, certData as CFData)!)
+            }
+        }
+        return certs
+    }
+
+    private static func stripPem(pem:String) -> String {
+        var text = pem.replacingOccurrences(of: "-----BEGIN CERTIFICATE-----", with: "", options: NSString.CompareOptions.literal, range:nil)
+        text = text.replacingOccurrences(of: "-----END CERTIFICATE-----", with: "", options: NSString.CompareOptions.literal, range:nil)
+        text = text.replacingOccurrences(of: "\n", with: "", options: NSString.CompareOptions.literal, range:nil)
+        text = text.replacingOccurrences(of: "\r", with: "", options: NSString.CompareOptions.literal, range:nil)
+        text = text.replacingOccurrences(of: "\t", with: "", options: NSString.CompareOptions.literal, range:nil)
+        return text
+    }
+}
+
+class TlsURLSessionRequestBuilderFactory: RequestBuilderFactory {
+    func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {
+        TlsURLSessionRequestBuilder<T>.self
+    }
+
+    func getBuilder<T: Decodable>() -> RequestBuilder<T>.Type {
+        TlsURLSessionDecodableRequestBuilder<T>.self
+    }
+}
+
+class TlsURLSessionRequestBuilder<T>: URLSessionRequestBuilder<T> {
+
+    fileprivate let sessionDelegate = URLSessionTrustDelegate()
+
+    override func createURLSession() -> URLSession {
+        let configuration = URLSessionConfiguration.default
+        configuration.httpAdditionalHeaders = buildHeaders()
+        return URLSession(configuration: configuration, delegate: sessionDelegate, delegateQueue: nil)
+    }
+}
+
+class TlsURLSessionDecodableRequestBuilder<T: Decodable>: URLSessionDecodableRequestBuilder<T> {
+
+    fileprivate let sessionDelegate = URLSessionTrustDelegate()
+    override func createURLSession() -> URLSession {
+        let configuration = URLSessionConfiguration.default
+        configuration.httpAdditionalHeaders = buildHeaders()
+        return URLSession(configuration: configuration, delegate: sessionDelegate, delegateQueue: nil)
+    }
+}
+
+class URLSessionTrustDelegate: NSObject, URLSessionDelegate {
+
+    // https://developer.apple.com/library/archive/technotes/tn2232/_index.html
+    // https://opensource.apple.com/source/libsecurity_keychain/libsecurity_keychain-55050.9/lib/Trust.cpp.auto.html
+
+    func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Swift.Void) {
+        if (challenge.protectionSpace.authenticationMethod != NSURLAuthenticationMethodServerTrust) {
+            completionHandler(.cancelAuthenticationChallenge, nil)
+            return
+        }
+
+        if let serverTrust = challenge.protectionSpace.serverTrust, let serverCert = SecTrustGetCertificateAtIndex(serverTrust, 0) {
+            let policy = SecPolicyCreateSSL(false, challenge.protectionSpace.host as CFString?)
+            var trust: SecTrust!
+            var status = SecTrustCreateWithCertificates([serverCert] as CFArray, policy, &trust)
+
+            let policies = NSMutableArray();
+            policies.add(policy)
+            SecTrustSetPolicies(trust, policies)
+
+            if (errSecSuccess != status) {
+                logTlsError(status, "Failed to create trust with cert", challenge)
+                completionHandler(.cancelAuthenticationChallenge, nil)
+                return
+            }
+
+            status = SecTrustSetAnchorCertificates(trust, SdkTls.trustedCerts as CFArray)
+            if (errSecSuccess != status) {
+                logTlsError(status, "Failed to set trust anchors", challenge)
+                completionHandler(.cancelAuthenticationChallenge, nil)
+                return
+            }
+
+            var secResult = SecTrustResultType.invalid
+            status = SecTrustEvaluate(trust, &secResult)
+            if (errSecSuccess != status) {
+                logTlsError(status, "Failed to evaluate trust", challenge)
+                return
+            }
+
+            if [.proceed, .unspecified].contains(secResult) {
+                print("TLS: Endpoint is trusted")
+                completionHandler(.useCredential, URLCredential(trust: trust))
+                return
+            } else {
+                logTlsError(secResult, "Failed to evaluate trust", challenge)
+                if let resultDict = SecTrustCopyResult(trust) {
+                    print("TLS: results=\(resultDict)")
+                }
+            }
+            logTlsError(serverCert: serverCert)
+        }
+
+        completionHandler(.cancelAuthenticationChallenge, nil)
+    }
+
+    fileprivate func logTlsError(_ status: OSStatus, _ msg:String, _ challenge:URLAuthenticationChallenge) {
+        print("TLS: \(msg) Status=\(status) Host=\(challenge.protectionSpace.host) Port=\(challenge.protectionSpace.port)")
+    }
+
+    fileprivate func logTlsError(_ status: SecTrustResultType, _ msg:String, _ challenge:URLAuthenticationChallenge) {
+        print("TLS: \(msg) Status=\(status) Host=\(challenge.protectionSpace.host) Port=\(challenge.protectionSpace.port)")
+    }
+
+    fileprivate func logTlsError(serverCert:SecCertificate) {
+        if let serverCertSummary = SecCertificateCopySubjectSummary(serverCert) {
+            print("TLS: Server cert '\(serverCertSummary)' did not match any of the following trusted CAs")
+            for trustedCert in SdkTls.trustedCerts {
+                if let trustedSummary = SecCertificateCopySubjectSummary(trustedCert) {
+                    print("TLS: Trusted=\(trustedSummary)")
+                }
+            }
+        }
+    }
+}

--- a/Sources/ff-ios-client-sdk/Events/EventSource.swift
+++ b/Sources/ff-ios-client-sdk/Events/EventSource.swift
@@ -91,6 +91,7 @@ open class EventSource: NSObject, EventSourceProtocol, URLSessionDataDelegate {
     private var operationQueue: OperationQueue
     private var mainQueue = DispatchQueue.main
     private var urlSession: URLSession?
+    private var tlsDelegate: URLSessionTrustDelegate?
 
     public init(
         url: URL,
@@ -102,6 +103,10 @@ open class EventSource: NSObject, EventSourceProtocol, URLSessionDataDelegate {
         readyState = EventSourceState.closed
         operationQueue = OperationQueue()
         operationQueue.maxConcurrentOperationCount = 1
+
+        if SdkTls.isTlsEnabled() {
+            self.tlsDelegate = URLSessionTrustDelegate()
+        }
 
         super.init()
     }
@@ -189,6 +194,10 @@ open class EventSource: NSObject, EventSourceProtocol, URLSessionDataDelegate {
         var newRequest = request
         self.headers.forEach { newRequest.setValue($1, forHTTPHeaderField: $0) }
         completionHandler(newRequest)
+    }
+
+    open func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Swift.Void) {
+        tlsDelegate?.urlSession(session, didReceive: challenge, completionHandler: completionHandler)
     }
 }
 


### PR DESCRIPTION
FFM-7015 - iOS SDK - TLS - support custom CAs

**What**
Adds TLS support for custom/private certs in the iOS SDK for config, stream and metric endpoints. The `CfConfigurationBuilder` now has new methods for taking a list of X.509 certificate authority (CA) certs. This list should also include any intermediate CAs the Apple security APIs may need to resolve the full trust chain. You will also need to ensure for custom certificates that the Subject Alternative Names (SANs) are setup correctly in the CA for domain name validation to pass.

`setTlsTrustedCAs(_ tlsTrustedCAs:[String])`

Takes a list of X.509 CA certificates in PEM format which will be used to verify the server's web cert sent during TLS handshake. Each PEM certificate should include the BEGIN/END CERTIFICATE headers.


**Why**
For non-SaaS deployments we want to be able to support custom CAs for private networks which are not widely bundled.

**Testing**
Manual with TLS termination on local proxy