### PR TITLE
FFM-8106 - initialize() will now correctly setup the SSE channel

### DIFF
--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -243,7 +243,7 @@ public class CfClient {
 
   /**
 	Completion block of this method will be called on each SSE response event.
-	This method needs to be called in order to get SSE events. Make sure to call [intialize](x-source-tag://initialize) prior to calling this method.
+	Make sure to call [intialize](x-source-tag://initialize) prior to calling this method.
 	- Parameters:
 		- events: An optional `[String]?`, representing the Events we want to subscribe to. Defaults to `[*]`, which subscribes to all events.
 		- onCompletion: Completion block containing `Swift.Result<EventType, CFError>`

--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -104,6 +104,7 @@ public class CfClient {
   private var analyticsCache = [String: AnalyticsWrapper]()
   private var lastPollTime: Date?
   private var minimumRefreshIntervalSecs = 60.0
+  private var currentState = State.offline
 
   //MARK: - Internal properties -
 
@@ -215,9 +216,27 @@ public class CfClient {
       case .success(_):
         OpenAPIClientAPI.streamPath = configuration.streamUrl
         OpenAPIClientAPI.eventPath = configuration.eventUrl
-        self.ready = true
-        SdkCodes.info_sdk_init_ok()
-        onCompletion?(.success(()))
+
+        var success = false
+        var err:CFError = CFError.authError(ErrorResponse.error(0, nil, nil))
+
+        self.registerEventsListener() { (result) in
+          switch (result) {
+          case .failure(let error):
+            success = false
+            err = error
+          case .success(_):
+            success = true
+          }
+        }
+
+        if (success) {
+          self.ready = true
+          SdkCodes.info_sdk_init_ok()
+          onCompletion?(.success(()))
+        } else {
+          onCompletion?(.failure(err))
+        }
       }
     }
   }
@@ -242,6 +261,7 @@ public class CfClient {
     onCompletion: @escaping (_ result: Swift.Result<EventType, CFError>) -> Void
   ) {
     guard isInitialized else { return }
+    self.clearEventsListener()
     let allKey = CfConstants.Persistance.features(
       self.configuration.environmentId, self.target.identifier
     ).value
@@ -293,6 +313,10 @@ public class CfClient {
     self.registerForNetworkConditionNotifications()
   }
 
+  func clearEventsListener() {
+    eventSourceManager?.clearEventCallbacks()
+  }
+  
   /**
 	Fetch `String` `Evaluation` from cache.
 	Make sure to call [intialize](x-source-tag://initialize) prior to calling this method.
@@ -667,6 +691,10 @@ public class CfClient {
 
   // Setup event observing flow based on `State`
   private func setupFlowFor(_ state: State) {
+    if (currentState == state) {
+      return
+    }
+
     switch state {
     case .offline:
       self.stopPolling()
@@ -689,6 +717,7 @@ public class CfClient {
       self.stopPolling()
       self.startStreaming()
     }
+    self.currentState = state;
   }
 
   //Setup network condition observing

--- a/Sources/ff-ios-client-sdk/Events/EventSource.swift
+++ b/Sources/ff-ios-client-sdk/Events/EventSource.swift
@@ -158,6 +158,13 @@ open class EventSource: NSObject, EventSourceProtocol, URLSessionDataDelegate {
     return Array(eventListeners.keys)
   }
 
+  func clearEventCallbacks() {
+    self.onOpenCallback = nil
+    self.onComplete = nil
+    self.onMessageCallback = nil
+    eventListeners.removeAll()
+  }
+  
   open func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
 
     if readyState != .open {
@@ -214,7 +221,11 @@ open class EventSource: NSObject, EventSourceProtocol, URLSessionDataDelegate {
     _ session: URLSession, didReceive challenge: URLAuthenticationChallenge,
     completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Swift.Void
   ) {
-    tlsDelegate?.urlSession(session, didReceive: challenge, completionHandler: completionHandler)
+    if let delegate = tlsDelegate {
+      delegate.urlSession(session, didReceive: challenge, completionHandler: completionHandler)
+    } else {
+      completionHandler(URLSession.AuthChallengeDisposition.rejectProtectionSpace, nil)
+    }
   }
 }
 

--- a/Sources/ff-ios-client-sdk/Network/EventSourceManager.swift
+++ b/Sources/ff-ios-client-sdk/Network/EventSourceManager.swift
@@ -23,6 +23,7 @@ protocol EventSourceManagerProtocol {
   func connect(lastEventId: String?)
   func disconnect()
   func destroy()
+  func clearEventCallbacks()
 }
 
 class EventSourceManager: EventSourceManagerProtocol {
@@ -76,6 +77,11 @@ class EventSourceManager: EventSourceManagerProtocol {
   }
 
   //MARK: - Internal methods -
+  
+  func clearEventCallbacks() {
+    eventSource?.clearEventCallbacks()
+  }
+
   func onOpen(_ completion: @escaping () -> Void) {
     eventSource?.onOpen {
       completion()

--- a/Tests/ff-ios-client-sdkTests/Mocks/EventSourceManagerMock.swift
+++ b/Tests/ff-ios-client-sdkTests/Mocks/EventSourceManagerMock.swift
@@ -9,6 +9,8 @@ import Foundation
 @testable import ff_ios_client_sdk
 
 class EventSourceManagerMock: EventSourceManagerProtocol {
+
+  
 	var forceDisconnected: Bool
 	var configuration: CfConfiguration?
 	var parameterConfig: ParameterConfig?
@@ -57,4 +59,7 @@ class EventSourceManagerMock: EventSourceManagerProtocol {
 	func destroy() {
 		self.streamReady = false
 	}
+  
+  func clearEventCallbacks() {
+  }
 }


### PR DESCRIPTION
FFM-8106 - initialize() will now correctly setup the SSE channel

What
Fix initialize to setup the SSE channel and/or polling. Currently it requires a 2nd call to registerEventsListener()

Why
Make client API more consistent with Android SDK.
The 2nd call is confusing for people learning the SDK for the first time as you won't see any events after init. registerEventsListener() should not setup the SSE channel instead it should just register callbacks.

Testing
Manual testing with proxy and unit testing