### PR TITLE
FFM-8049 - iOS SDK - Retry on Client Authentication failures

### DIFF
--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -186,6 +186,8 @@ public class CfClient {
     _ onCompletion: ((Swift.Result<Void, CFError>) -> Void)? = nil
 
   ) {
+    OpenAPIClientAPI.requestBuilderFactory = RetryURLSessionRequestBuilderFactory()
+    
     if let factory = configuration.loggerFactory {
       SdkLog.setLoggerFactory(factory)
     } else if configuration.debug {
@@ -221,7 +223,7 @@ public class CfClient {
       }
     }
   }
-
+  
   /**
 	Completion block of this method will be called on each SSE response event.
 	This method needs to be called in order to get SSE events. Make sure to call [intialize](x-source-tag://initialize) prior to calling this method.
@@ -705,7 +707,7 @@ public class CfClient {
         if self.configuration.streamEnabled {
           self.setupFlowFor(.onlineStreaming)
         }
-        CfClient.log.info("Polling ENABLED due to NETWORK AVAILABLE")
+        CfClient.log.debug("Polling/Streaming ENABLED due to NETWORK AVAILABLE")
       } else {
         self.setupFlowFor(.offline)
         CfClient.log.info("Polling/Streaming DISABLED due to NO NETWORK")
@@ -738,7 +740,6 @@ public class CfClient {
     //ON OPEN
     eventSourceManager.onOpen {
       CfClient.log.info("SSE connection has been opened")
-      SdkCodes.info_stream_connected()
 
       onEvent(EventType.onOpen, nil)
 

--- a/Sources/ff-ios-client-sdk/Common/SdkTls.swift
+++ b/Sources/ff-ios-client-sdk/Common/SdkTls.swift
@@ -66,15 +66,29 @@ class TlsURLSessionRequestBuilder<T>: URLSessionRequestBuilder<T> {
     configuration.httpAdditionalHeaders = buildHeaders()
     return URLSession(configuration: configuration, delegate: sessionDelegate, delegateQueue: nil)
   }
+  
+  required public init(method: String, URLString: String, parameters: [String : Any]?, isBody: Bool, headers: [String : String] = [:]) {
+    super.init(method: method, URLString: URLString, parameters: parameters, isBody: isBody, headers: headers)
+    let handler = RetryHandler(URLString)
+    super.taskCompletionShouldRetry = handler.taskCompletionShouldRetry
+  }
+  
 }
 
 class TlsURLSessionDecodableRequestBuilder<T: Decodable>: URLSessionDecodableRequestBuilder<T> {
 
   fileprivate let sessionDelegate = URLSessionTrustDelegate()
+
   override func createURLSession() -> URLSession {
     let configuration = URLSessionConfiguration.default
     configuration.httpAdditionalHeaders = buildHeaders()
     return URLSession(configuration: configuration, delegate: sessionDelegate, delegateQueue: nil)
+  }
+  
+  required public init(method: String, URLString: String, parameters: [String : Any]?, isBody: Bool, headers: [String : String] = [:]) {
+    super.init(method: method, URLString: URLString, parameters: parameters, isBody: isBody, headers: headers)
+    let handler = RetryHandler(URLString)
+    super.taskCompletionShouldRetry = handler.taskCompletionShouldRetry
   }
 }
 

--- a/Sources/ff-ios-client-sdk/Common/UrlSessionRetry.swift
+++ b/Sources/ff-ios-client-sdk/Common/UrlSessionRetry.swift
@@ -1,0 +1,125 @@
+//
+//  File.swift
+//
+//
+//  Created by Andrew Bell on 29/06/2023.
+//
+
+import Foundation
+
+class RetryHandler {
+  private static let log = SdkLog.get("io.harness.ff.sdk.ios.RetryHandler")
+  private var attempt = 0
+  private let maxAttempts = 3
+  private let delaySec = Double.random(in: 5...10)
+  private let url:String
+
+  init(_ url:String) {
+    self.url = url
+  }
+
+  func taskCompletionShouldRetry(data:Data?, response:URLResponse?, error:Error?, shouldRetryCallback:@escaping (Bool) -> Void) -> Void {
+    RetryHandler.log.trace("Enter retry handler")
+
+    if (attempt >= maxAttempts) {
+      RetryHandler.log.warn("Max retries reached for \(url)")
+      attempt = 0
+      shouldRetryCallback(false)
+      return
+    }
+
+    var shouldRetry = false
+
+    if let httpResponse = response as? HTTPURLResponse {
+      if httpResponse.statusCode == 200 {
+        RetryHandler.log.trace("Skip retry, got HTTP status code 200 on endpoint: \(url)")
+        shouldRetry = false
+      } else if shouldRetryHttpCode(httpResponse.statusCode) {
+        RetryHandler.log.warn("Retrying, got HTTP status code \(httpResponse.statusCode) on endpoint: \(url)")
+        shouldRetry = true
+      }
+    } else if let err = error {
+      RetryHandler.log.warn("Endpoint \(url) got error: \(err)")
+      shouldRetry =  shouldRetryError(error)
+    } else {
+      shouldRetry = false
+    }
+
+    if (shouldRetry) {
+      attempt += 1
+      let delaySec = delaySec * Double(attempt)
+      RetryHandler.log.warn("Retrying request #\(attempt) of #\(maxAttempts) in \(String(format: "%.3f", delaySec)) seconds for \(url)")
+      Thread.sleep(forTimeInterval: delaySec)
+      shouldRetryCallback(true)
+    } else {
+      shouldRetryCallback(false)
+    }
+
+    RetryHandler.log.trace("Exit retry handler")
+  }
+
+  /*
+   408 request timeout
+   425 too early
+   429 too many requests
+   500 internal server error
+   502 bad gateway
+   503 service unavailable
+   504 gateway timeout
+    -1 OpenAPI error (timeout etc)
+   */
+  func shouldRetryHttpCode(_ code:Int) -> Bool {
+    switch (code) {
+    case 408,425,429,500,502,503,504,-1:
+      return true
+    default:
+      return false
+    }
+  }
+
+  func shouldRetryError(_ error:Error?) -> Bool {
+    if let err = error as? NSError {
+      RetryHandler.log.trace("Check if error should be retried: code=\(err.code) domain=\(err.domain)")
+
+      if let causeErr = err.userInfo[NSUnderlyingErrorKey] as? NSError,
+        let code = causeErr.userInfo["_kCFStreamErrorCodeKey"] as? Int {
+        RetryHandler.log.trace("underlyingError: code=\(code) domain=\(causeErr.domain)")
+        return causeErr.domain == kCFErrorDomainCFNetwork as String && code == -2102 // kCFStreamErrorRequestTimeout
+      }
+
+      return err.domain == kCFErrorDomainCFNetwork as String
+    }
+    return false
+  }
+}
+
+class RetryURLSessionRequestBuilderFactory: RequestBuilderFactory {
+  func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {
+    return RetryURLSessionRequestBuilder<T>.self
+  }
+
+  func getBuilder<T:Decodable>() -> RequestBuilder<T>.Type {
+    return RetryURLSessionDecodableRequestBuilder<T>.self
+  }
+}
+
+class RetryURLSessionRequestBuilder<T>: URLSessionRequestBuilder<T> {
+
+  required public init(method: String, URLString: String, parameters: [String : Any]?, isBody: Bool, headers: [String : String] = [:]) {
+    super.init(method: method, URLString: URLString, parameters: parameters, isBody: isBody, headers: headers)
+    let handler = RetryHandler(URLString)
+    super.taskCompletionShouldRetry = handler.taskCompletionShouldRetry
+  }
+}
+
+class RetryURLSessionDecodableRequestBuilder<T: Decodable>: URLSessionDecodableRequestBuilder<T> {
+
+  required public init(method: String, URLString: String, parameters: [String : Any]?, isBody: Bool, headers: [String : String] = [:]) {
+    super.init(method: method, URLString: URLString, parameters: parameters, isBody: isBody, headers: headers)
+    let handler = RetryHandler(URLString)
+    super.taskCompletionShouldRetry = handler.taskCompletionShouldRetry
+  }
+}
+
+
+

--- a/Sources/ff-ios-client-sdk/Events/EventSource.swift
+++ b/Sources/ff-ios-client-sdk/Events/EventSource.swift
@@ -177,7 +177,7 @@ open class EventSource: NSObject, EventSourceProtocol, URLSessionDataDelegate {
   ) {
 
     completionHandler(URLSession.ResponseDisposition.allow)
-
+    SdkCodes.info_stream_connected()
     readyState = .open
     mainQueue.async { [weak self] in self?.onOpenCallback?() }
   }


### PR DESCRIPTION
FFM-8049 - iOS SDK - Retry on Client Authentication failures

What
Add a new retry handler which will override the taskCompletionShouldRetry() callback provided by OpenAPI. Timeouts and certain error codes will be retried with a random delay up to 3 times before the request completion handler is called.

Why
The current implementation will fail straight away without attempting to retry a few times, causing defaults to be served in cases where a recoverable transient network error happened.

Testing
Manual testing as part of the 1.1.0 release see epic for full list FFM-8042