### PR TITLE
FFM-8360 - iOS SDK - Remove NSLog calls and use Logger instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can also add the `ff-ios-client-sdk` dependency locally by dragging the SDK 
 
 ```Swift
 dependencies: [
-	.package(url: "https://github.com/harness/ff-ios-client-sdk.git", .upToNextMinor(from: "1.0.4"))
+	.package(url: "https://github.com/harness/ff-ios-client-sdk.git", .upToNextMinor(from: "1.1.0"))
 ]
 ```
 &nbsp;

--- a/Sources/ff-ios-client-sdk/API/OpenAPIs/APIs.swift
+++ b/Sources/ff-ios-client-sdk/API/OpenAPIs/APIs.swift
@@ -9,7 +9,7 @@ import Foundation
 open class OpenAPIClientAPI {
 	
     public static var configPath = CfConstants.Server.configUrl // "https://config.ff.harness.io/api/1.0"
-	public static var streamPath = CfConstants.Server.streamUrl // "https://config.ff.harness.io/api/1.0"
+    public static var streamPath = CfConstants.Server.streamUrl // "https://config.ff.harness.io/api/1.0"
     public static var eventPath = CfConstants.Server.eventUrl   // "https://events.ff.harness.io/api/1.0"
     
     public static var credential: URLCredential?
@@ -19,6 +19,7 @@ open class OpenAPIClientAPI {
 }
 
 open class RequestBuilder<T> {
+    private let log = SdkLog.get("io.harness.ff.sdk.ios.RequestBuilder")
     var credential: URLCredential?
     var headers: [String:String]
     public let parameters: [String:Any]?
@@ -51,8 +52,7 @@ open class RequestBuilder<T> {
         addHeaders(additionalHeaders)
         
         for (header, value) in self.headers {
-            
-            NSLog("Header: \(header) -> \(value)")
+            log.debug("Header: \(header) -> \(value)")
         }
     }
 

--- a/Sources/ff-ios-client-sdk/API/OpenAPIsio/harness/ff/api/DefaultAPI.swift
+++ b/Sources/ff-ios-client-sdk/API/OpenAPIsio/harness/ff/api/DefaultAPI.swift
@@ -8,6 +8,9 @@
 import Foundation
 
 open class DefaultAPI {
+
+    private static let log = SdkLog.get("io.harness.ff.sdk.ios.DefaultAPI")
+
     /**
      Authenticate with the admin server.
      
@@ -157,7 +160,7 @@ open class DefaultAPI {
             method: "GET", URLString: (url?.string ?? URLString), parameters: parameters, isBody: false
         )
         
-        NSLog("API getEvaluations: \(req.URLString)")
+        DefaultAPI.log.debug("API getEvaluations: \(req.URLString)")
         return req
     }
     
@@ -199,7 +202,7 @@ open class DefaultAPI {
             method: "GET", URLString: (url?.string ?? URLString), parameters: parameters, isBody: false
         )
         
-        NSLog("API getEvaluationByIdentifier: \(req.URLString)")
+        DefaultAPI.log.debug("API getEvaluationByIdentifier: \(req.URLString)")
         return req
     }
 }

--- a/Sources/ff-ios-client-sdk/API/OpenAPIsio/harness/ff/api/MetricsAPI.swift
+++ b/Sources/ff-ios-client-sdk/API/OpenAPIsio/harness/ff/api/MetricsAPI.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 open class MetricsAPI {
-    
+
+    private static let log = SdkLog.get("io.harness.ff.sdk.ios.MetricsAPI")
+
     /**
      Post metrics data.
      
@@ -76,7 +78,7 @@ open class MetricsAPI {
             isBody: true
         )
         
-        NSLog("API postMetrics: URL=\(req.URLString), HEADERS=\(req.headers), METHOD=\(req.method)")
+        MetricsAPI.log.debug("API postMetrics: URL=\(req.URLString), HEADERS=\(req.headers), METHOD=\(req.method)")
         return req
     }
 }

--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -790,12 +790,14 @@ public class CfClient {
       self.setupFlowFor(.onlinePolling)
       guard error == nil else {
 
-        NSLog("Api, eventSourceManager.onComplete: \(error!)")
+        let errStr = error?.localizedDescription ?? ""
+        CfClient.log.warn("Api, eventSourceManager.onComplete: error=\(errStr)")
         onEvent(EventType.onComplete, error)
         return
       }
 
-      NSLog("Api, eventSourceManager.onComplete: \(statusCode!)")
+      let statusStr = statusCode ?? -1;
+      CfClient.log.info("Api, eventSourceManager.onComplete: status=\(statusStr)")
       onEvent(EventType.onComplete, nil)
     }
 


### PR DESCRIPTION
FFM-8360 - iOS SDK - Remove NSLog calls and use Logger instead

What
Avoid calling NSLog directly from source

Why
Better to call Logger instead so that logs can be filtered depending on their level

Testing
Manual + see FFM-8042