### PR TITLE
[FFM-9282] - Fix runtime failure when target is nil

### DIFF
--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -235,6 +235,7 @@ public class CfClient {
 
         if (success) {
           self.ready = true
+          CfClient.log.info("SDK version: \(Version.version)")
           SdkCodes.info_sdk_init_ok()
           onCompletion?(.success(()))
         } else {

--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -60,7 +60,7 @@ public class CfClient {
     case offline
   }
 
-  private init(
+  internal init(
 
     authenticationManager: AuthenticationManagerProtocol = AuthenticationManager(),
     networkInfoProvider: NetworkInfoProviderProtocol = NetworkInfoProvider()
@@ -69,6 +69,7 @@ public class CfClient {
     self.authenticationManager = authenticationManager
     self.eventSourceManager = EventSourceManager.shared()
     self.networkInfoProvider = networkInfoProvider
+    self.target = CfTarget.builder().setIdentifier("").build()
   }
 
   private var lastEventId: String?
@@ -109,7 +110,7 @@ public class CfClient {
   //MARK: - Internal properties -
 
   var configuration: CfConfiguration!
-  var target: CfTarget!
+  var target: CfTarget
   var authenticationManager: AuthenticationManagerProtocol!
   var eventSourceManager: EventSourceManagerProtocol!
   var onPollingResultCallback: ((Swift.Result<EventType, CFError>) -> Void)?
@@ -602,7 +603,7 @@ public class CfClient {
     }
   }
 
-  private func fetchIfReady(
+  internal func fetchIfReady(
 
     evaluationId: String,
     defaultValue: Any? = nil,
@@ -618,11 +619,15 @@ public class CfClient {
     case is [String: ValueType]: valueType = ValueType.object(defaultValue as! [String: ValueType])
     default: valueType = nil
     }
-    if ready {
+    if ready && target.isValid() {
       self.getEvaluationById(
         forKey: evaluationId, target: target.identifier, defaultValue: valueType,
         completion: completion)
     } else {
+      if !target.isValid() {
+        CfClient.log.warn("Target has not yet been set");
+      }
+
       guard let defaultValue = valueType else {
         completion(nil)
         return

--- a/Sources/ff-ios-client-sdk/Version.swift
+++ b/Sources/ff-ios-client-sdk/Version.swift
@@ -2,5 +2,5 @@ import Foundation
 
 class Version {
 
-  static let version: String = "1.1.0"
+  static let version: String = "1.1.1"
 }

--- a/Tests/ff-ios-client-sdkTests/TestCases/CfClientTest.swift
+++ b/Tests/ff-ios-client-sdkTests/TestCases/CfClientTest.swift
@@ -1,0 +1,22 @@
+//
+//  CfClientTest.swift
+//  ff-ios-client-sdkTests
+//
+//  Created by Andrew Bell on 08/09/2023.
+//
+
+import XCTest
+
+@testable import ff_ios_client_sdk
+
+final class CfClientTest: XCTestCase {
+
+    func testShouldNotThrowFatalErrorIfTargetIsNull() throws {
+      let client = CfClient()
+
+      client.fetchIfReady(evaluationId: "flag", defaultValue: "defaultValue", { (eval) in
+        print("fetchIfReady returns: \(eval!)")
+      })
+    }
+
+}

--- a/ff-ios-client-sdk.podspec
+++ b/ff-ios-client-sdk.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |ff|
 
   ff.name         = "ff-ios-client-sdk"
-  ff.version      = "1.1.0"
+  ff.version      = "1.1.1"
   ff.summary      = "iOS SDK for Harness Feature Flags Management"
 
   ff.description  = <<-DESC


### PR DESCRIPTION
[FFM-9282] - Fix runtime failure when target is nil

What
Change target from implicitly-unwrapped optional to non-optional to avoid nil dereference errors. Also set the target to a default value in the constructor and add some additional isValid() checks to avoid cache lookups when the target is not yet known.

Why
SDK can throw an exception when initialization has not completed and boolVariation is called, this is because target has not been set yet.

Testing
New unit test + manual

[FFM-9282]: https://harness.atlassian.net/browse/FFM-9282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ