### PR TITLE
FFM-9409 - Metrics payload incorrectly sending global target identifier

### DIFF
--- a/Sources/ff-ios-client-sdk/API/OpenAPIsio/harness/ff/model/metrics/SummaryMetrics.swift
+++ b/Sources/ff-ios-client-sdk/API/OpenAPIsio/harness/ff/model/metrics/SummaryMetrics.swift
@@ -5,17 +5,20 @@ import Foundation
     public var featureName: String
     public var variationValue: String
     public var variationIdentifier: String
+    public var target: String
     
     init (
     
         featureName: String,
         variationValue: String,
-        variationIdentifier: String
+        variationIdentifier: String,
+        target: String
     
     ) {
         
         self.featureName = featureName
         self.variationValue = variationValue
         self.variationIdentifier = variationIdentifier
+        self.target = target
     }
 }

--- a/Sources/ff-ios-client-sdk/API/OpenAPIsio/harness/ff/model/metrics/SummaryMetrics.swift
+++ b/Sources/ff-ios-client-sdk/API/OpenAPIsio/harness/ff/model/metrics/SummaryMetrics.swift
@@ -5,7 +5,7 @@ import Foundation
     public var featureName: String
     public var variationValue: String
     public var variationIdentifier: String
-    public var target: String
+    public var targetIdentifier: String
     
     init (
     

--- a/Sources/ff-ios-client-sdk/API/OpenAPIsio/harness/ff/model/metrics/SummaryMetrics.swift
+++ b/Sources/ff-ios-client-sdk/API/OpenAPIsio/harness/ff/model/metrics/SummaryMetrics.swift
@@ -12,13 +12,13 @@ import Foundation
         featureName: String,
         variationValue: String,
         variationIdentifier: String,
-        target: String
+        targetIdentifier: String
     
     ) {
         
         self.featureName = featureName
         self.variationValue = variationValue
         self.variationIdentifier = variationIdentifier
-        self.target = target
+        self.targetIdentifier = targetIdentifier
     }
 }

--- a/Sources/ff-ios-client-sdk/Analytics/AnalyticsPublisherService.swift
+++ b/Sources/ff-ios-client-sdk/Analytics/AnalyticsPublisherService.swift
@@ -129,7 +129,7 @@ class AnalyticsPublisherService {
         KeyValue(
 
           key: AnalyticsPublisherService.TARGET_ATTRIBUTE,
-          value: key.target
+          value: key.targetIdentifier
         )
       )
       attributes.append(
@@ -178,7 +178,7 @@ class AnalyticsPublisherService {
       featureName: key.variation.name,
       variationValue: key.variation.value,
       variationIdentifier: key.variation.identifier,
-      target: key.target.identifier
+      targetIdentifier: key.target.identifier
     )
   }
 

--- a/Sources/ff-ios-client-sdk/Analytics/AnalyticsPublisherService.swift
+++ b/Sources/ff-ios-client-sdk/Analytics/AnalyticsPublisherService.swift
@@ -11,7 +11,6 @@ class AnalyticsPublisherService {
   private static let SDK_TYPE: String = "SDK_TYPE"
   private static let SDK_VERSION: String = "SDK_VERSION"
   private static let SDK_LANGUAGE: String = "SDK_LANGUAGE"
-  private static let GLOBAL_TARGET: String = "__global__cf_target"
   private static let TARGET_ATTRIBUTE: String = "target"
   private static let FEATURE_NAME_ATTRIBUTE: String = "featureName"
   private static let VARIATION_IDENTIFIER_ATTRIBUTE: String = "variationIdentifier"

--- a/Sources/ff-ios-client-sdk/Analytics/AnalyticsPublisherService.swift
+++ b/Sources/ff-ios-client-sdk/Analytics/AnalyticsPublisherService.swift
@@ -130,7 +130,7 @@ class AnalyticsPublisherService {
         KeyValue(
 
           key: AnalyticsPublisherService.TARGET_ATTRIBUTE,
-          value: AnalyticsPublisherService.GLOBAL_TARGET
+          value: key.target
         )
       )
       attributes.append(
@@ -178,7 +178,8 @@ class AnalyticsPublisherService {
 
       featureName: key.variation.name,
       variationValue: key.variation.value,
-      variationIdentifier: key.variation.identifier
+      variationIdentifier: key.variation.identifier,
+      target: key.target.identifier
     )
   }
 

--- a/Sources/ff-ios-client-sdk/Version.swift
+++ b/Sources/ff-ios-client-sdk/Version.swift
@@ -2,5 +2,5 @@ import Foundation
 
 class Version {
 
-  static let version: String = "1.1.1"
+  static let version: String = "1.1.2"
 }

--- a/ff-ios-client-sdk.podspec
+++ b/ff-ios-client-sdk.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |ff|
 
   ff.name         = "ff-ios-client-sdk"
-  ff.version      = "1.1.1"
+  ff.version      = "1.1.2"
   ff.summary      = "iOS SDK for Harness Feature Flags Management"
 
   ff.description  = <<-DESC


### PR DESCRIPTION
 [FFM-9409] - Metrics payload incorrectly sending global target identifier

What
Fix AnalyticsPublisherService to send the target id in metric payload's target attribute.

Why
The SDK is sending `__global__cf_target` in the metrics payload, not the real target.

Testing
Manual

[FFM-9409]: https://harness.atlassian.net/browse/FFM-9409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ