### PR TITLE
FFM-10516 Add completion handler to `destroy` (close) method

### DIFF
--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -33,6 +33,11 @@ public enum EventType: Equatable {
     case onEventListener
     case onPolling
   }
+    
+  enum DestructionResult {
+    case success
+    case failure(reason: String)
+  }
 
   var comparableType: ComparableType {
     switch self {
@@ -43,6 +48,7 @@ public enum EventType: Equatable {
     case .onPolling: return .onPolling
     }
   }
+    
 
   static public func == (lhs: EventType, rhs: EventType) -> Bool {
     return lhs.comparableType.rawValue == rhs.comparableType.rawValue
@@ -494,34 +500,55 @@ public class CfClient {
     }
   }
 
-  /**
-	 Clears the occupied resources and shuts down the sdk.
-	 After calling this method, the [intialize](x-source-tag://initialize) must be called again. It will also
-	 remove any registered event listeners.
-	*/
-  public func destroy(completion: @escaping () -> Void) {
-    if self.configuration != nil {
+    /**
+     Clears the occupied resources and shuts down the SDK. This method performs necessary cleanup and resets various components.
+     After calling this method, the SDK is no longer functional until it is reinitialized with the [initialize](x-source-tag://initialize) method.
+     
+     The method accepts a completion handler that returns a `DestructionResult` enum. This enum indicates whether the destruction process was successful (`DestructionResult.success`) or failed (`DestructionResult.failure(reason: String)`), along with a reason for the failure.
+     
+     It is recommended to handle the completion to understand the outcome of the destruction process, especially for debugging and proper resource management.
+     
+     Note: If the SDK is alre
+     */
+    public func destroy(completion: @escaping (DestructionResult) -> Void) {
+        if self.configuration != nil {
+            // Existing destruction logic...
+            self.pollingEnabled = false
+            self.eventSourceManager.destroy()
+            self.setupFlowFor(.offline)
+            self.configuration.streamEnabled = false
+            self.isInitialized = false
+            self.lastEventId = nil
+            self.onPollingResultCallback = nil
+            self.featureRepository.defaultAPIManager = nil
+            self.analyticsManager?.destroy()
+            self.ready = false
+            CfClient.sharedInstance.dispose()
+            CfClient.log.info("SDK shut down succesfully")
 
-      self.pollingEnabled = false
-      self.eventSourceManager.destroy()
-      self.setupFlowFor(.offline)
-      self.configuration.streamEnabled = false
-      self.isInitialized = false
-      self.lastEventId = nil
-      self.onPollingResultCallback = nil
-      self.featureRepository.defaultAPIManager = nil
-      self.analyticsManager?.destroy()
-      self.ready = false
-      CfClient.sharedInstance.dispose()
-      completion()
-
-    } else {
-
-      CfClient.log.warn("destroy() already called. Please reinitialize the SDK.")
-      completion()
-
+            // Indicate success
+            completion(.success)
+        } else {
+            CfClient.log.warn("destroy() already called. Please reinitialize the SDK.")
+            // Indicate failure with reason
+            completion(.failure(reason: "SDK already destroyed or uninitialized."))
+        }
     }
-  }
+    
+    
+    public func destroy() {
+        destroy { result in
+            switch result {
+            case .success:
+                break
+            case .failure(let reason):
+                // Log the failure reason or handle it as necessary
+                CfClient.log.warn("Failed to destroy SDK: \(reason)")
+            }
+        }
+    }
+
+
 
   //MARK: - Private methods -
 

--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -499,7 +499,7 @@ public class CfClient {
 	 After calling this method, the [intialize](x-source-tag://initialize) must be called again. It will also
 	 remove any registered event listeners.
 	*/
-  public func destroy() {
+  public func destroy(completion: @escaping () -> Void) {
     if self.configuration != nil {
 
       self.pollingEnabled = false
@@ -513,9 +513,13 @@ public class CfClient {
       self.analyticsManager?.destroy()
       self.ready = false
       CfClient.sharedInstance.dispose()
+      completion()
+
     } else {
 
       CfClient.log.warn("destroy() already called. Please reinitialize the SDK.")
+      completion()
+
     }
   }
 

--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -524,13 +524,11 @@ public class CfClient {
             self.analyticsManager?.destroy()
             self.ready = false
             CfClient.sharedInstance.dispose()
+            
             CfClient.log.info("SDK shut down succesfully")
-
-            // Indicate success
             completion(.success)
         } else {
             CfClient.log.warn("destroy() already called. Please reinitialize the SDK.")
-            // Indicate failure with reason
             completion(.failure(reason: "SDK already destroyed or uninitialized."))
         }
     }
@@ -542,7 +540,6 @@ public class CfClient {
             case .success:
                 break
             case .failure(let reason):
-                // Log the failure reason or handle it as necessary
                 CfClient.log.warn("Failed to destroy SDK: \(reason)")
             }
         }

--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -33,11 +33,6 @@ public enum EventType: Equatable {
     case onEventListener
     case onPolling
   }
-    
-  enum DestructionResult {
-    case success
-    case failure(reason: String)
-  }
 
   var comparableType: ComparableType {
     switch self {
@@ -65,6 +60,11 @@ public class CfClient {
     case onlinePolling
     case offline
   }
+    
+    public enum DestructionResult {
+        case success
+        case failure(reason: String)
+    }
 
   internal init(
 
@@ -510,7 +510,7 @@ public class CfClient {
      
      Note: If the SDK is already destroyed or uninitialized, calling this method will result in a failure response.
      */
-    public func destroy(completion: @escaping (DestructionResult) -> Void) {
+    public func destroy(completion: @escaping (_ result: DestructionResult) -> Void) {
         if self.configuration != nil {
             // Existing destruction logic...
             self.pollingEnabled = false

--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -508,7 +508,7 @@ public class CfClient {
      
      It is recommended to handle the completion to understand the outcome of the destruction process, especially for debugging and proper resource management.
      
-     Note: If the SDK is alre
+     Note: If the SDK is already destroyed or uninitialized, calling this method will result in a failure response.
      */
     public func destroy(completion: @escaping (DestructionResult) -> Void) {
         if self.configuration != nil {


### PR DESCRIPTION
# What
Adds a completion handler to the `destroy` method, which will indicate if it is succesfull  or not. Provides an overloaded method with the original signature to keep backwards compatability.

# Why
The Flutter SDK is hanging on iOS when `destroy` is called. This change allows Flutter to determine if the SDK has been shut down correctly, and can cease to hang by returning the result back to the core Flutter code. 

# Testing
Manual using sample app for both overloaded `destroy` methods