### PR TITLE
FFM-10601 - Fix race condition in Metrics map

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/ff-ios-client-sdk.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ff-ios-client-sdk.xcscheme
@@ -41,6 +41,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference

--- a/Package.swift
+++ b/Package.swift
@@ -15,11 +15,16 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
+        .package(url: "https://github.com/apple/swift-atomics.git", .upToNextMajor(from: "1.2.0")),
+        .package(url: "https://github.com/peterprokop/SwiftConcurrentCollections.git", .branch("master"))
     ],
     targets: [
         .target(
             name: "ff-ios-client-sdk",
-            dependencies: [],
+            dependencies: [
+                .product(name: "Atomics", package: "swift-atomics"),
+                .product(name: "SwiftConcurrentCollections", package: "SwiftConcurrentCollections")
+            ],
 			path: "Sources/ff-ios-client-sdk"),
         .testTarget(
             name: "ff-ios-client-sdkTests",

--- a/Sources/ff-ios-client-sdk/API/OpenAPIsio/harness/ff/api/MetricsAPI.swift
+++ b/Sources/ff-ios-client-sdk/API/OpenAPIsio/harness/ff/api/MetricsAPI.swift
@@ -13,7 +13,7 @@ open class MetricsAPI {
      - parameter apiResponseQueue: The queue on which api response is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func postMetrics(
+    open func postMetrics(
         
         environmentUUID: String,
         cluster: String,
@@ -47,7 +47,7 @@ open class MetricsAPI {
      - parameter metrics: Metrics data.
      - returns: RequestBuilder<EmptyResponse>
      */
-    open class func postMetricsRequestBuilder(
+    open func postMetricsRequestBuilder(
         
         environmentUUID: String,
         cluster: String,

--- a/Sources/ff-ios-client-sdk/API/OpenAPIsio/harness/ff/model/metrics/AnalyticsWrapper.swift
+++ b/Sources/ff-ios-client-sdk/API/OpenAPIsio/harness/ff/model/metrics/AnalyticsWrapper.swift
@@ -1,13 +1,41 @@
 import Foundation
+import Atomics
 
 @objc public class AnalyticsWrapper : NSObject, Codable {
     
-    public var analytics: Analytics
-    public var count: Int
-    
-    init (analytics: Analytics, count: Int) {
-        
-        self.analytics = analytics
-        self.count = count
-    }
+  public var analytics: Analytics
+  private var counter: ManagedAtomic<Int>
+
+  init (analytics: Analytics, count: Int) {
+      self.analytics = analytics
+      self.counter = ManagedAtomic<Int>(0)
+  }
+
+  public func increment() {
+    counter.wrappingIncrement(ordering: .relaxed)
+  }
+
+  public func count() -> Int {
+    return counter.load(ordering: .relaxed)
+  }
+
+  private enum CodingKeys : String, CodingKey {
+    case analytics
+    case counter
+
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(count(), forKey: .counter)
+    try container.encode(analytics, forKey: .analytics)
+  }
+
+  required public init(from decoder: Decoder) throws {
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+    self.analytics = try values.decode(Analytics.self, forKey: .analytics)
+    let c = try values.decode(Int.self, forKey: .counter)
+    self.counter = ManagedAtomic<Int>(c)
+  }
+
 }

--- a/Sources/ff-ios-client-sdk/Analytics/AnalyticsManager.swift
+++ b/Sources/ff-ios-client-sdk/Analytics/AnalyticsManager.swift
@@ -56,7 +56,7 @@ class AnalyticsManager: Destroyable {
         cacheSnapshot[key] = v
       }
     }
-    AnalyticsManager.log.info("Sending metrics")
+    AnalyticsManager.log.info("Sending \(cacheSnapshot.count) metrics")
     service.sendDataAndResetCache(cache: cacheSnapshot)
   }
 

--- a/Sources/ff-ios-client-sdk/Analytics/AnalyticsManager.swift
+++ b/Sources/ff-ios-client-sdk/Analytics/AnalyticsManager.swift
@@ -8,6 +8,7 @@ class AnalyticsManager: Destroyable {
   private let cluster: String
   private let authToken: String
   private let config: CfConfiguration
+  private let metricsApi: MetricsAPI
 
   private var ready: Bool
   private var timer: Timer?
@@ -19,7 +20,8 @@ class AnalyticsManager: Destroyable {
     cluster: String,
     authToken: String,
     config: CfConfiguration,
-    cache: inout [String: AnalyticsWrapper]
+    cache: inout [String: AnalyticsWrapper],
+    metricsApi: MetricsAPI = MetricsAPI()
 
   ) {
 
@@ -27,6 +29,7 @@ class AnalyticsManager: Destroyable {
     self.cluster = cluster
     self.authToken = authToken
     self.config = config
+    self.metricsApi = metricsApi
     self.cache = cache
     self.ready = true
 
@@ -41,7 +44,8 @@ class AnalyticsManager: Destroyable {
 
       cluster: self.cluster,
       environmentID: self.environmentID,
-      config: self.config
+      config: self.config,
+      metricsApi: self.metricsApi
     )
 
     analyticsPublisherService.sendDataAndResetCache(cache: &self.cache)

--- a/Sources/ff-ios-client-sdk/Analytics/AnalyticsManager.swift
+++ b/Sources/ff-ios-client-sdk/Analytics/AnalyticsManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftConcurrentCollections
 
 class AnalyticsManager: Destroyable {
 
@@ -9,20 +10,19 @@ class AnalyticsManager: Destroyable {
   private let authToken: String
   private let config: CfConfiguration
   private let metricsApi: MetricsAPI
+  private let analyticsPublisherService: AnalyticsPublisherService
 
   private var ready: Bool
   private var timer: Timer?
-  private var cache: [String: AnalyticsWrapper]
+  private var cache: ConcurrentDictionary<String, AnalyticsWrapper>
 
   init(
-
     environmentID: String,
     cluster: String,
     authToken: String,
     config: CfConfiguration,
-    cache: inout [String: AnalyticsWrapper],
+    cache: inout ConcurrentDictionary<String, AnalyticsWrapper>,
     metricsApi: MetricsAPI = MetricsAPI()
-
   ) {
 
     self.environmentID = environmentID
@@ -33,22 +33,31 @@ class AnalyticsManager: Destroyable {
     self.cache = cache
     self.ready = true
 
-    SdkCodes.info_metrics_thread_started()
-  }
-
-  @objc func send() {
-
-    AnalyticsManager.log.info("Sending metrics")
-
-    let analyticsPublisherService = AnalyticsPublisherService(
-
+    self.analyticsPublisherService = AnalyticsPublisherService(
       cluster: self.cluster,
       environmentID: self.environmentID,
       config: self.config,
       metricsApi: self.metricsApi
     )
 
-    analyticsPublisherService.sendDataAndResetCache(cache: &self.cache)
+    self.timer = Timer.scheduledTimer( withTimeInterval: TimeInterval(config.analyticsFrequency), repeats: true) { timer in
+      AnalyticsManager.send(self.analyticsPublisherService, self.cache);
+    }
+
+    AnalyticsManager.log.debug("Scheduled metrics timer")
+    SdkCodes.info_metrics_thread_started()
+  }
+
+  class func send(_ service: AnalyticsPublisherService, _ cache: ConcurrentDictionary<String, AnalyticsWrapper>) {
+    // Create a working snapshot of the cache so it doesn't get modified underneath us
+    var cacheSnapshot = [String: AnalyticsWrapper]()
+    for key in cache.keys {
+      if let v = cache.remove(key) {
+        cacheSnapshot[key] = v
+      }
+    }
+    AnalyticsManager.log.info("Sending metrics")
+    service.sendDataAndResetCache(cache: cacheSnapshot)
   }
 
   func push(
@@ -82,33 +91,16 @@ class AnalyticsManager: Destroyable {
       AnalyticsManager.log.trace("Metrics data appended [1], \(variation.name) has count of: 1")
     } else {
 
-      wrapper?.count += 1
+      wrapper?.increment()
       if let w = wrapper {
 
         AnalyticsManager.log.trace(
-          "Metrics data appended [2], \(variation.name) has count of: \(w.count)")
+          "Metrics data appended [2], \(variation.name) has count of: \(w.count())")
       } else {
 
         AnalyticsManager.log.trace(
           "Metrics data appended [3], \(variation.name) has count of: ERROR")
       }
-    }
-
-    if self.timer == nil {
-
-      AnalyticsManager.log.debug("Scheduling metrics timer")
-
-      self.timer = Timer.scheduledTimer(
-
-        timeInterval: TimeInterval(config.analyticsFrequency),
-        target: self,
-        selector: #selector(send),
-        userInfo: nil,
-        repeats: true
-      )
-    } else {
-
-      AnalyticsManager.log.trace("Scheduling metrics timer SKIPPED")
     }
   }
 
@@ -118,7 +110,6 @@ class AnalyticsManager: Destroyable {
 
     ready = false
     self.timer?.invalidate()
-    self.timer = nil
   }
 
   private func getAnalyticsCacheKey(

--- a/Sources/ff-ios-client-sdk/Analytics/AnalyticsPublisherService.swift
+++ b/Sources/ff-ios-client-sdk/Analytics/AnalyticsPublisherService.swift
@@ -6,6 +6,7 @@ class AnalyticsPublisherService {
   private let cluster: String
   private let environmentID: String
   private let config: CfConfiguration
+  private let metricsApi: MetricsAPI
 
   private static let CLIENT: String = "client"
   private static let SDK_TYPE: String = "SDK_TYPE"
@@ -19,13 +20,15 @@ class AnalyticsPublisherService {
 
     cluster: String,
     environmentID: String,
-    config: CfConfiguration
+    config: CfConfiguration,
+    metricsApi: MetricsAPI
 
   ) {
 
     self.config = config
     self.cluster = cluster
     self.environmentID = environmentID
+    self.metricsApi = metricsApi
   }
 
   func sendDataAndResetCache(cache: inout [String: AnalyticsWrapper]) {
@@ -42,7 +45,7 @@ class AnalyticsPublisherService {
 
         if !metricsData.isEmpty {
 
-          MetricsAPI.postMetrics(
+          metricsApi.postMetrics(
 
             environmentUUID: environmentID,
             cluster: cluster,

--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftConcurrentCollections
 
 ///An enum with associated values,  representing possible event types.
 /// - `case` onOpen(`String`)
@@ -108,7 +109,7 @@ public class CfClient {
   private var ready: Bool = false
 
   private var analyticsManager: AnalyticsManager?
-  private var analyticsCache = [String: AnalyticsWrapper]()
+  private var analyticsCache = ConcurrentDictionary<String, AnalyticsWrapper>()
   private var lastPollTime: Date?
   private var minimumRefreshIntervalSecs = 60.0
   private var currentState = State.offline

--- a/Sources/ff-ios-client-sdk/Network/AnalyticsAPIManager.swift
+++ b/Sources/ff-ios-client-sdk/Network/AnalyticsAPIManager.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  AnalyticsAPIManagerProtocol.swift
 //
 //
 //  Created by Milos Vasic on 22.6.21..
@@ -15,6 +15,7 @@ protocol AnalyticsAPIManagerProtocol {
     cluster: String,
     metrics: Metrics,
     apiResponseQueue: DispatchQueue,
+    metricsApi: MetricsAPI,
     completion: @escaping ((EmptyResponse?, CFError?) -> Void)
   )
 }
@@ -27,11 +28,12 @@ class AnalyticsAPIManager: AnalyticsAPIManagerProtocol {
     cluster: String,
     metrics: Metrics,
     apiResponseQueue: DispatchQueue,
+    metricsApi: MetricsAPI,
     completion: @escaping ((EmptyResponse?, CFError?) -> Void)
 
   ) {
 
-    MetricsAPI.postMetrics(
+    metricsApi.postMetrics(
 
       environmentUUID: environmentUUID,
       cluster: cluster,

--- a/Sources/ff-ios-client-sdk/Version.swift
+++ b/Sources/ff-ios-client-sdk/Version.swift
@@ -2,5 +2,5 @@ import Foundation
 
 class Version {
 
-  static let version: String = "1.1.3"
+  static let version: String = "1.2.0"
 }

--- a/Tests/ff-ios-client-sdkTests/TestCases/Analytics/AnalyticsManagerTest.swift
+++ b/Tests/ff-ios-client-sdkTests/TestCases/Analytics/AnalyticsManagerTest.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 import XCTest
+import SwiftConcurrentCollections
 
 @testable import ff_ios_client_sdk
 
@@ -58,7 +59,7 @@ final class AnalyticsManagerTest: XCTestCase {
   func testConcurrentMetricsMapModifications() throws {
 
     let config = CfConfiguration.builder().build()
-    var cache = [String: AnalyticsWrapper]()
+    var cache = ConcurrentDictionary<String, AnalyticsWrapper>()
     let analyticsManager = AnalyticsManager(
       environmentID: "dummy",
       cluster: "dummy",

--- a/Tests/ff-ios-client-sdkTests/TestCases/Analytics/AnalyticsManagerTest.swift
+++ b/Tests/ff-ios-client-sdkTests/TestCases/Analytics/AnalyticsManagerTest.swift
@@ -1,0 +1,87 @@
+//
+//  AnalyticsManagerTest.swift
+//
+//
+//  Created by Andrew Bell on 07/02/2024.
+//
+
+import Foundation
+
+import XCTest
+
+@testable import ff_ios_client_sdk
+
+class EvalThread : Thread {
+  let latch = DispatchGroup()
+  let analyticsManager: AnalyticsManager
+  let target = CfTarget.builder().setIdentifier("Dummy").build()
+
+  init(_ analyticsManager: AnalyticsManager) {
+    self.analyticsManager = analyticsManager
+  }
+
+  override func start() {
+    print("start thread: ", self.debugDescription)
+    latch.enter()
+    super.start()
+  }
+
+  override func main() {
+    print("run thread:", self.debugDescription)
+
+    let variation = Variation(identifier: "id", value: "val", name: "name")
+
+    for _ in 1...100 {
+      analyticsManager.push(target: target, variation: variation)
+    }
+
+    latch.leave()
+  }
+
+  func join() {
+    latch.wait()
+    print("joined thread released:", self.debugDescription)
+  }
+}
+
+class DummyMetricsApi : MetricsAPI {
+  override func postMetrics(environmentUUID: String, cluster: String, metrics: Metrics, apiResponseQueue: DispatchQueue = OpenAPIClientAPI.apiResponseQueue, completion: @escaping ((EmptyResponse?, Error?) -> Void)) {
+    print("postMetrics called")
+  }
+}
+
+/*
+ * This test uses several threads to concurrently update the metrics map to force out any critical regions that aren't protected.
+ * In particular the metrics dictionary.
+ */
+final class AnalyticsManagerTest: XCTestCase {
+  func testConcurrentMetricsMapModifications() throws {
+
+    let config = CfConfiguration.builder().build()
+    var cache = [String: AnalyticsWrapper]()
+    let analyticsManager = AnalyticsManager(
+      environmentID: "dummy",
+      cluster: "dummy",
+      authToken: "dummy",
+      config: config,
+      cache: &cache,
+      metricsApi: DummyMetricsApi()
+    )
+
+    var threads: Array<EvalThread> = Array()
+
+    for _ in 1...20 {
+      threads.append(EvalThread(analyticsManager))
+
+    }
+
+    for thread in threads {
+      thread.start()
+    }
+
+    for thread in threads {
+      thread.join()
+    }
+
+  }
+}

--- a/Tests/ff-ios-client-sdkTests/TestCases/Analytics/AnalyticsManagerTest.swift
+++ b/Tests/ff-ios-client-sdkTests/TestCases/Analytics/AnalyticsManagerTest.swift
@@ -22,7 +22,7 @@ class EvalThread : Thread {
   }
 
   override func start() {
-    print("start thread: ", self.debugDescription)
+    print("start thread:", self.debugDescription)
     latch.enter()
     super.start()
   }
@@ -47,7 +47,17 @@ class EvalThread : Thread {
 
 class DummyMetricsApi : MetricsAPI {
   override func postMetrics(environmentUUID: String, cluster: String, metrics: Metrics, apiResponseQueue: DispatchQueue = OpenAPIClientAPI.apiResponseQueue, completion: @escaping ((EmptyResponse?, Error?) -> Void)) {
-    print("postMetrics called")
+
+    var counter = 0;
+
+    if let metrics = metrics.metricsData {
+      for m in metrics {
+        counter += m.count
+      }
+    }
+
+    print("postMetrics called: total=\(counter)")
+
   }
 }
 

--- a/Tests/ff-ios-client-sdkTests/TestCases/Models/EventSourceManagerTest.swift
+++ b/Tests/ff-ios-client-sdkTests/TestCases/Models/EventSourceManagerTest.swift
@@ -64,7 +64,21 @@ class EventSourceManagerTest: XCTestCase {
     XCTAssertTrue(callbackCalled)
     XCTAssertEqual(id, resultID)
     XCTAssertEqual(event, resultEvent)
-    XCTAssertEqual(data, resultData)
+
+    do {
+      if let expectedJson = try JSONSerialization.jsonObject(with: Data(data.utf8), options: []) as? [String: Any],
+         let actualJson = try JSONSerialization.jsonObject(with: Data(resultData.utf8), options: []) as? [String: Any] {
+
+        XCTAssertEqual(expectedJson["version"] as? Int, actualJson["version"] as? Int)
+        XCTAssertEqual(expectedJson["event"] as? String, actualJson["event"] as? String)
+        XCTAssertEqual(expectedJson["identifier"] as? String, actualJson["identifier"] as? String)
+        XCTAssertEqual(expectedJson["domain"] as? String, actualJson["domain"] as? String)
+      } else {
+        XCTFail("JSONSerialization failed")
+      }
+    } catch let error as NSError {
+      XCTFail(error.description)
+    }
   }
 
   func testAddEventListenerFailure() {

--- a/ff-ios-client-sdk.podspec
+++ b/ff-ios-client-sdk.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |ff|
 
   ff.name         = "ff-ios-client-sdk"
-  ff.version      = "1.1.3"
+  ff.version      = "1.2.0"
   ff.summary      = "iOS SDK for Harness Feature Flags Management"
 
   ff.description  = <<-DESC


### PR DESCRIPTION
FFM-10601 - Fix race condition in Metrics map

**What**
Update metrics map elements to use thread safe data structures. Also update code to drain map on each iteration atomically by loading metrics to be posted into a secondary non-shared working map to reduce critical regions in the code.

Bump version number since we're now bring in some extra deps.

**Why**
We're getting reports of EXC_BAD_ACCESS on the metrics map.

**Testing**
New unit tests added to stress metrics map with multiple threads and XCode thread sanitizer + manual
