### PR TITLE
FFM-8138 Handle SSE deletes + don't sent metrics when default variation served

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ class ViewController: UIViewController {
                     print("Event: SSE stream has been opened")
                   case .onMessage(let messageObj):
                     print(messageObj?.event ?? "Event: Message received")
+                  case .onDelete(let flagID):
+                    print("Flag was deleted:, \(flagID!)")
                 }
             }
           }

--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -943,21 +943,12 @@ public class CfClient {
                   })
               }
             } else if decoded.event == "delete" {
-                // Check if decoded.identifier (the flag ID) is available
                 if let flagIdToDelete = decoded.identifier, !flagIdToDelete.isEmpty {
-                    // Call deleteEvaluations to remove all evaluations associated with the flag ID from the cache
                     self.featureRepository.deleteEvaluations(forFlagId: flagIdToDelete, target: self.target.identifier, onCompletion: { result in
                         switch result {
                         case .failure(let error):
-                            // Handle the error case, e.g., by logging or notifying a listener
-                            // TODO add this log message to the error that was passed
-                            CfClient.log.info("Failed to delete evaluations from cache after '\(flagIdToDelete) was deleted, reason: \(error)")
                             onEvent(EventType.onDelete(nil), error)
                         case .success():
-                            // Optionally, notify that the evaluations for the flag were successfully deleted.
-                            // This example uses nil to indicate successful deletion without specifying an evaluation,
-                            // but you should adjust this based on your event handling needs.
-                            CfClient.log.info("Deleted evaluations from cache because flag '\(flagIdToDelete)' was deleted")
                             onEvent(EventType.onDelete(flagIdToDelete), nil)
                         }
                     })

--- a/Sources/ff-ios-client-sdk/Network/FeatureRepository.swift
+++ b/Sources/ff-ios-client-sdk/Network/FeatureRepository.swift
@@ -183,12 +183,10 @@ class FeatureRepository {
         let allKey = CfConstants.Persistance.features(self.config.environmentId, target).value
 
         do {
-            // Attempt to fetch the list of all evaluations from cache
             if var allEvaluations: [Evaluation] = try self.storageSource.getValue(forKey: allKey) {
                 // Filter out the evaluations that match the flag ID to delete
                 allEvaluations.removeAll { $0.flag == flagId }
                 
-                // Save the updated list of evaluations back to cache
                 try self.storageSource.saveValue(allEvaluations, key: allKey)
             }
             FeatureRepository.logger.debug("Deleted evaluations from cache because flag '\(flagId)' was deleted")

--- a/Sources/ff-ios-client-sdk/Network/FeatureRepository.swift
+++ b/Sources/ff-ios-client-sdk/Network/FeatureRepository.swift
@@ -183,19 +183,33 @@ class FeatureRepository {
         let allKey = CfConstants.Persistance.features(self.config.environmentId, target).value
 
         do {
-            if var allEvaluations: [Evaluation] = try self.storageSource.getValue(forKey: allKey) {
-                // Filter out the evaluations that match the flag ID to delete
-                allEvaluations.removeAll { $0.flag == flagId }
+            // Attempt to fetch the list of all evaluations from cache
+            if let allEvaluations: [Evaluation] = try self.storageSource.getValue(forKey: allKey) {
+                // Filter to find evaluations that match the flag ID to delete
+                let evaluationsToDelete = allEvaluations.filter { $0.flag == flagId }
                 
-                try self.storageSource.saveValue(allEvaluations, key: allKey)
+                // Iterate over these evaluations and remove each from the cache individually
+                for evaluation in evaluationsToDelete {
+                    let individualKey = CfConstants.Persistance.feature(self.config.environmentId, target, evaluation.identifier).value
+                    try self.storageSource.removeValue(forKey: individualKey)
+                }
+                
+                // Also update the allEvaluations list by removing the deleted evaluations and save it back to cache
+                let updatedEvaluations = allEvaluations.filter { $0.flag != flagId }
+                try self.storageSource.saveValue(updatedEvaluations, key: allKey)
+
+                FeatureRepository.logger.debug("Successfully deleted evaluations for flag '\(flagId)' from cache")
+                onCompletion(.success(()))
+            } else {
+                // A very unlikely, but possible, state: if no evaluations present then nothing to delete.
+                onCompletion(.success(()))
             }
-            FeatureRepository.logger.debug("Deleted evaluations from cache because flag '\(flagId)' was deleted")
-            onCompletion(.success(()))
         } catch {
-            FeatureRepository.logger.warn("Flag |\(flagId)| was deleted, but failed to remove its evaluations from cache")
+            FeatureRepository.logger.warn("Failed to delete evaluations for flag |\(flagId)| from cache")
             onCompletion(.failure(CFError.storageError))
         }
     }
+
 
 
 

--- a/Sources/ff-ios-client-sdk/Version.swift
+++ b/Sources/ff-ios-client-sdk/Version.swift
@@ -2,5 +2,5 @@ import Foundation
 
 class Version {
 
-  static let version: String = "1.2.0"
+  static let version: String = "1.3.0"
 }

--- a/ff-ios-client-sdk.podspec
+++ b/ff-ios-client-sdk.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |ff|
 
   ff.name         = "ff-ios-client-sdk"
-  ff.version      = "1.2.0"
+  ff.version      = "1.3.0"
   ff.summary      = "iOS SDK for Harness Feature Flags Management"
 
   ff.description  = <<-DESC


### PR DESCRIPTION
# What
- Previously, if a flag was deleted, the SDK would simply ignore the event. However, users need to be informed so that they can evaluate the flag and fall back to the default variation they provide, so that they are no longer using a deleted flag's variation. 
This PR ensures that when a flag is deleted, the SDK removes all related evaluations from its cache, and emits a new `onDelete` event that users can listen for and act on. It was not possible to use the event for regular streaming changes, because its payload was an `Evaluation` which is not compatible with simply sending the identifier of the flag that was deleted. 

- Also stops sending metrics when the default variation was used.

# Testing
Manual
- Archived flag to trigger new event. 
- Trigger default variation for existing flag - metrics not registered in UI
