### PR TITLE
[FFM-11492] - Treat projectIdentifier as optional in auth token

### DIFF
--- a/Sources/ff-ios-client-sdk/Models/CfProject.swift
+++ b/Sources/ff-ios-client-sdk/Models/CfProject.swift
@@ -2,23 +2,23 @@ import Foundation
 
 @objc public class CfProject: NSObject, Codable {
 	
-    public var projectIdentifier: String
+  public var projectIdentifier: String
 	public var organization: String
 	public var project: String
 	public var environmentIdentifier: String
 	public var environment: String
 	public var accountID: String
-    public var clusterIdentifier: String
+  public var clusterIdentifier: String
 	
 	public init(dict:[String:Any]) {
 		
-        self.projectIdentifier = 	 dict["projectIdentifier"] as! String
-		self.organization = 	 	 dict["organization"] as! String
-		self.project = 			 	 dict["project"] as! String
-		self.environmentIdentifier = dict["environmentIdentifier"] as! String
-		self.environment = 			 dict["environment"] as! String
-		self.accountID = 			 dict["accountID"] as! String
-        self.clusterIdentifier =     dict["clusterIdentifier"] as! String
+    self.projectIdentifier     = dict["projectIdentifier"] as? String ?? ""
+		self.organization          = dict["organization"] as? String ?? ""
+		self.project               = dict["project"] as? String ?? ""
+		self.environmentIdentifier = dict["environmentIdentifier"] as? String ?? ""
+		self.environment           = dict["environment"] as? String ?? ""
+		self.accountID             = dict["accountID"] as? String ?? ""
+    self.clusterIdentifier     = dict["clusterIdentifier"] as? String ?? ""
 	}
 }
 

--- a/Sources/ff-ios-client-sdk/Version.swift
+++ b/Sources/ff-ios-client-sdk/Version.swift
@@ -2,5 +2,5 @@ import Foundation
 
 class Version {
 
-  static let version: String = "1.3.0"
+  static let version: String = "1.3.1"
 }

--- a/ff-ios-client-sdk.podspec
+++ b/ff-ios-client-sdk.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |ff|
 
   ff.name         = "ff-ios-client-sdk"
-  ff.version      = "1.3.0"
+  ff.version      = "1.3.1"
   ff.summary      = "iOS SDK for Harness Feature Flags Management"
 
   ff.description  = <<-DESC


### PR DESCRIPTION
**What**
We're seeing a nil reference reported against the proxy V2 on iOS because the auth token does not include certain fields.

**Why**
Original token parsing code expects all fields to be present and force unwraps them. Instead we should set any missing fields to an empty string.

**Testing**
Manual