### PR TITLE
FFM-12241 Fix jsonVariation encoding issue

### DIFF
--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -1119,7 +1119,6 @@ extension String {
                 return String(data: cleanData, encoding: .utf8) ?? innerString
             }
         } catch {
-            print("JSON double unescaping error: \(error)")
             log.warn("JSON double unescaping error: \(error)")
         }
         

--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -467,7 +467,7 @@ public class CfClient {
             // Open api generator is double escaping json strings.  This is a workaround, to manually double unescape them.
             if let jsonString = evaluation.value.stringValue {
                 // Unescape the JSON string
-                let unescapedString = jsonString.doubleUnescapeJSONString()
+                let unescapedString = jsonString.doubleUnescapeJSONString(log: CfClient.log)
                 // Create a new Evaluation with the unescaped string
                 let parsedEvaluation = Evaluation(flag: evaluation.flag, identifier: evaluation.identifier, value: .string(unescapedString))
                 completion(parsedEvaluation)
@@ -509,7 +509,7 @@ public class CfClient {
                 // Defensive check: Ensure `stringValue` is valid
                 if let jsonString = eval.value.stringValue {
                     // Open api generator is double escaping json strings.  This is a workaround, to manually double unescape them.
-                    result = jsonString.doubleUnescapeJSONString()
+                    result = jsonString.doubleUnescapeJSONString(log: CfClient.log)
                 } else {
                     // Defensive check, string values are always returned from ff-server. But in case there has been an issue, log a warning and return the default.
                     CfClient.log.warn("Expected a JSON string for evaluation '\(evaluationId)', but received a non-string value. Returning default variation.")
@@ -1098,7 +1098,7 @@ public class CfClient {
 }
 
 extension String {
-    func doubleUnescapeJSONString() -> String {
+    func doubleUnescapeJSONString(log: any SdkLogger) -> String {
         // get as JSON fragment (a JSON-encoded string)
         guard let firstData = self.data(using: .utf8) else {
             return self
@@ -1120,6 +1120,7 @@ extension String {
             }
         } catch {
             print("JSON double unescaping error: \(error)")
+            log.warn("JSON double unescaping error: \(error)")
         }
         
         return self

--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -1108,9 +1108,9 @@ extension String {
             // Allow fragments to handle the top-level string
             let jsonFragment = try JSONSerialization.jsonObject(with: firstData, options: .allowFragments)
             
-            // The result should be a string representing the inner JSON
+            // The result should be a string representing the inner json
             if let innerString = jsonFragment as? String {
-                // Step 2: Now parse the innerString as actual JSON
+                // Now parse the innerString as actual JSON
                 guard let secondData = innerString.data(using: .utf8) else {
                     return innerString
                 }

--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -465,7 +465,6 @@ public class CfClient {
             }
             
             // Open api generator is double escaping json strings.  This is a workaround, to manually double unescape them.
-            // 
             if let jsonString = evaluation.value.stringValue {
                 // Unescape the JSON string
                 let unescapedString = jsonString.doubleUnescapeJSONString()

--- a/Sources/ff-ios-client-sdk/Version.swift
+++ b/Sources/ff-ios-client-sdk/Version.swift
@@ -2,5 +2,5 @@ import Foundation
 
 class Version {
 
-  static let version: String = "1.3.1"
+  static let version: String = "1.3.2"
 }

--- a/ff-ios-client-sdk.podspec
+++ b/ff-ios-client-sdk.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |ff|
 
   ff.name         = "ff-ios-client-sdk"
-  ff.version      = "1.3.1"
+  ff.version      = "1.3.2"
   ff.summary      = "iOS SDK for Harness Feature Flags Management"
 
   ff.description  = <<-DESC


### PR DESCRIPTION
# What
The opan api generated code is double escaping json strings, before returning them back to the core SDK code.  E.g.

`"\"{\\\"key1\\\":\\\"val1\\\"}\""`

The fix is to remove remove the escaped characters, attempt to parse as a valid JSON Object, then encode back to a jsonString.  
We can rely on this double escaping to occur and therefore the fix, as FF Server always returns strings for all flags, including json flags.  

Note: I investigated the possibility of re-generating the opan api code with a potential flag to stop this from occuring, but I could not find anything.

# Testing

JSON Flag definitions:

// Json array 
`[{"mykey":"myval", "123": "456",   "nestedArray": [1, 2, 3, 4]}, {"mykey2":"myval2"}]`

// Json object
`{"mykey":"myval", "123": "456", "nestedArray": [1, 2, 3, 4]}`

The resulting strings are valid json strings and can decoded into json objects using

`let jsonObject = try JSONSerialization.jsonObject(with: jsonData, options: [])`