### PR TITLE
FFM-12381 - Avoid blocking main thread when writing disk cache

### DIFF
--- a/Sources/ff-ios-client-sdk/Version.swift
+++ b/Sources/ff-ios-client-sdk/Version.swift
@@ -2,5 +2,5 @@ import Foundation
 
 class Version {
 
-  static let version: String = "1.3.2"
+  static let version: String = "1.3.3"
 }

--- a/Tests/ff-ios-client-sdkTests/Mocks/CacheMocks.swift
+++ b/Tests/ff-ios-client-sdkTests/Mocks/CacheMocks.swift
@@ -50,7 +50,7 @@ struct CacheMocks {
 			}
 		}
 	}
-	static func createFlagMocks(_ type: ValueType? = nil, count: Int) -> [Evaluation]  {
+	static func createFlagMocks(_ type: ValueType? = nil, count: Int, evalId: String = "test") -> [Evaluation]  {
 		var mocks = [Evaluation]()
 		for _ in 0..<count  {
 			if let type = type {
@@ -63,11 +63,11 @@ struct CacheMocks {
 			} else {
 				let random = Int(arc4random_uniform(UInt32(TestFlagValue.RawValue.allCases.count)))
 				let randomValueType = TestFlagValue(TestFlagValue.RawValue(rawValue: random)!)
-                mocks.append(.init(flag: randomValueType.key, identifier: "test", value: randomValueType.value))
+                mocks.append(.init(flag: randomValueType.key, identifier: evalId, value: randomValueType.value))
 			}
 		}
-        return mocks
-    }
+    return mocks
+  }
 	
 	static func createEvalForStringType(_ string: String) -> Evaluation? {
 		switch string {

--- a/Tests/ff-ios-client-sdkTests/TestCases/CFAPI/RegisterForEventsTest.swift
+++ b/Tests/ff-ios-client-sdkTests/TestCases/CFAPI/RegisterForEventsTest.swift
@@ -134,6 +134,10 @@ class RegisterForEventsTest: XCTestCase {
           callbackCalled = true
           XCTAssertEqual(eventType.comparableType, EventType.ComparableType.onEventListener)
           exp.fulfill()
+        case .onDelete(_):
+          callbackCalled = true
+          XCTAssertEqual(eventType.comparableType, EventType.ComparableType.onEventListener)
+          exp.fulfill()
         }
       }
     }

--- a/Tests/ff-ios-client-sdkTests/TestCases/Models/CFCacheTest.swift
+++ b/Tests/ff-ios-client-sdkTests/TestCases/Models/CFCacheTest.swift
@@ -27,7 +27,21 @@ class CfCacheTest: XCTestCase {
     XCTAssertTrue(type(of: sut) === CfCache.self)
   }
 
+
   //MARK: Writing Tests
+
+  func testWritingLotsOfDataDoesNotDeadlock() {
+    let tempCache = CfCache();
+
+    do {
+      for i in 0..<1000 {
+        let value: Evaluation = CacheMocks.createFlagMocks(count: 100, evalId: "eval\(i)").first!
+        try tempCache.saveValue(value, key: key)
+      }
+    } catch {}
+
+  }
+
   func testSaveValueSuccess() {
     // Given
     let value: Evaluation = CacheMocks.createFlagMocks(count: 1).first!

--- a/ff-ios-client-sdk.podspec
+++ b/ff-ios-client-sdk.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |ff|
 
   ff.name         = "ff-ios-client-sdk"
-  ff.version      = "1.3.2"
+  ff.version      = "1.3.3"
   ff.summary      = "iOS SDK for Harness Feature Flags Management"
 
   ff.description  = <<-DESC


### PR DESCRIPTION
Fixes an issue where main thread can be blocked if disk writing takes up a lot of time. Update `saveToDisk` to use `DispatchQueue.async` so the main thread returns immediately
