### PR TITLE
fix: [FFM-12394]: Fail-fast when we fail to get evaluations on init

### DIFF
--- a/Sources/ff-ios-client-sdk/Builders/CfConfigurationBuilder.swift
+++ b/Sources/ff-ios-client-sdk/Builders/CfConfigurationBuilder.swift
@@ -25,7 +25,8 @@ public class CfConfigurationBuilder {
       environmentId: "",
       tlsTrustedCAs: [],
       loggerFactory: nil,
-      debug: false
+      debug: false,
+      failFastOnInit: false
     )
   }
   /**
@@ -113,6 +114,17 @@ public class CfConfigurationBuilder {
      */
   public func setDebug(_ debug: Bool) -> CfConfigurationBuilder {
     config.debug = debug
+    return self
+  }
+
+  /**
+    When the initialize() function is called, any startup errors will be reported immediately in the completion handler, including (but not limited to):
+     * Get all evaluations will immediately return a failure instead of using the cache
+
+     - Parameter failFastOnInit: true to enable. Set to `false` by default.
+     */
+  public func setFailFastOnInit(_ failFastOnInit: Bool) -> CfConfigurationBuilder {
+    config.failFastOnInit = failFastOnInit
     return self
   }
 

--- a/Sources/ff-ios-client-sdk/Builders/CfConfigurationBuilder.swift
+++ b/Sources/ff-ios-client-sdk/Builders/CfConfigurationBuilder.swift
@@ -119,7 +119,8 @@ public class CfConfigurationBuilder {
 
   /**
     When the initialize() function is called, any startup errors will be reported immediately in the completion handler, including (but not limited to):
-     * Get all evaluations will immediately return a failure instead of using the cache
+      * Get all evaluations will immediately return a failure instead of using the cache
+      * Disable retries when getting evaluations on init
 
      - Parameter failFastOnInit: true to enable. Set to `false` by default.
      */

--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -188,8 +188,12 @@ public class CfClient {
     lifecycleLock.lock()
         defer { lifecycleLock.unlock() }
     self.isDestroyed = false
-    OpenAPIClientAPI.requestBuilderFactory = RetryURLSessionRequestBuilderFactory()
-    
+
+    if !configuration.failFastOnInit {
+      // Enable retries
+      OpenAPIClientAPI.requestBuilderFactory = RetryURLSessionRequestBuilderFactory()
+    }
+
     if let factory = configuration.loggerFactory {
       SdkLog.setLoggerFactory(factory)
     } else if configuration.debug {

--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -271,9 +271,11 @@ public class CfClient {
   ) {
     guard isInitialized else { return }
     self.clearEventsListener()
+
     let allKey = CfConstants.Persistance.features(
       self.configuration.environmentId, self.target.identifier
     ).value
+
     do {
       let initialEvaluations: [Evaluation]? = try self.featureRepository.storageSource.getValue(
         forKey: allKey)
@@ -281,10 +283,10 @@ public class CfClient {
     } catch {
       CfClient.log.warn("Could not fetch from cache")
     }
+
     if self.configuration.streamEnabled, let token = self.token {
 
       let parameterConfig = ParameterConfig(
-
         headers: [
           CFHTTPHeaderField.authorization.rawValue: "Bearer \(token)",
           CFHTTPHeaderField.apiKey.rawValue: self.apiKey,
@@ -294,12 +296,14 @@ public class CfClient {
         ],
         cluster: self.cluster!
       )
+
       self.eventSourceManager.configuration = self.configuration
       self.eventSourceManager.parameterConfig = parameterConfig
 
       if self.eventSourceManager.forceDisconnected {
         self.setupFlowFor(.onlinePolling)
       }
+
       startStream(events) { (startStreamResult) in
         switch startStreamResult {
         case .failure(let error):
@@ -308,6 +312,7 @@ public class CfClient {
           onCompletion(.success(eventType))
         }
       }
+
     } else {
       self.setupFlowFor(.onlinePolling)
     }

--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -213,6 +213,7 @@ public class CfClient {
     OpenAPIClientAPI.eventPath = configuration.eventUrl
 
     let authRequest = AuthenticationRequest(apiKey: apiKey, target: target)
+
     self.authenticate(authRequest, cache: cache) { (response) in
 
       switch response {
@@ -630,8 +631,6 @@ public class CfClient {
         return
       }
 
-      SdkCodes.info_sdk_auth_ok()
-
       //Set storage to provided cache or CfCache by default
       self.storageSource = cache
 
@@ -670,14 +669,18 @@ public class CfClient {
       // Initial getEvaluations to be stored in cache
       self.featureRepository.getEvaluations(onCompletion: { [weak self] (result) in
         guard let self = self else { return }
+
         let allKey = CfConstants.Persistance.features(
           self.configuration.environmentId, self.target.identifier
         ).value
+
         switch result {
         case .success(let evaluations):
           do {
             try self.storageSource?.saveValue(evaluations, key: allKey)
             self.lastPollTime = Date()
+
+            SdkCodes.info_sdk_auth_ok()
             onCompletion(.success(()))
           } catch {
             //If saving to cache fails, pass success for authorization and continue

--- a/Sources/ff-ios-client-sdk/CfConfiguration.swift
+++ b/Sources/ff-ios-client-sdk/CfConfiguration.swift
@@ -23,6 +23,7 @@ public struct CfConfiguration {
   var tlsTrustedCAs: [String]
   var loggerFactory: SdkLoggerFactory?
   var debug: Bool
+  var failFastOnInit: Bool
 
   internal init(
 
@@ -35,8 +36,8 @@ public struct CfConfiguration {
     environmentId: String,
     tlsTrustedCAs: [String],
     loggerFactory: SdkLoggerFactory?,
-    debug: Bool
-
+    debug: Bool,
+    failFastOnInit: Bool = false
   ) {
 
     self.configUrl = configUrl
@@ -50,6 +51,7 @@ public struct CfConfiguration {
     self.tlsTrustedCAs = tlsTrustedCAs
     self.loggerFactory = loggerFactory
     self.debug = debug
+    self.failFastOnInit = failFastOnInit
   }
 
   public static func builder() -> CfConfigurationBuilder {

--- a/Sources/ff-ios-client-sdk/Network/FeatureRepository.swift
+++ b/Sources/ff-ios-client-sdk/Network/FeatureRepository.swift
@@ -60,18 +60,11 @@ class FeatureRepository {
         self.config.environmentId, self.target.identifier
       ).value
       switch result {
-      case .failure(_):
-        FeatureRepository.logger.warn("Failed getting ALL from CLOUD. Try CACHE/STORAGE")
-        do {
-          let evals: [Evaluation]? = try self.storageSource.getValue(forKey: allKey)
-          onCompletion(.success(evals ?? []))
-          FeatureRepository.logger.debug("SUCCESS: Got ALL from CACHE/STORAGE")
-        } catch {
-          FeatureRepository.logger.warn("FAILURE: Unable to get ALL from CACHE/STORAGE")
-          onCompletion(.failure(CFError.storageError))
-        }
+      case .failure(let err):
+        FeatureRepository.logger.warn("Failed getting all evaluations from cloud")
+        onCompletion(.failure(err))
       case .success(let evaluations):
-        FeatureRepository.logger.debug("SUCCESS: Got ALL from CLOUD")
+        FeatureRepository.logger.debug("SUCCESS: Got all evaluations from cloud")
 
         for eval in evaluations {
           let key = CfConstants.Persistance.feature(

--- a/Sources/ff-ios-client-sdk/Network/FeatureRepository.swift
+++ b/Sources/ff-ios-client-sdk/Network/FeatureRepository.swift
@@ -60,11 +60,23 @@ class FeatureRepository {
         self.config.environmentId, self.target.identifier
       ).value
       switch result {
-      case .failure(let err):
-        FeatureRepository.logger.warn("Failed getting all evaluations from cloud")
-        onCompletion(.failure(err))
+      case .failure(let error):
+        if config.failFastOnInit {
+          FeatureRepository.logger.warn("Failed getting all evaluations from cloud.")
+          onCompletion(.failure(error))
+        } else {
+          FeatureRepository.logger.warn("Failed getting all evaluations from CLOUD. Try CACHE/STORAGE")
+          do {
+            let evals: [Evaluation]? = try self.storageSource.getValue(forKey: allKey)
+            onCompletion(.success(evals ?? []))
+            FeatureRepository.logger.debug("SUCCESS: Got all evaluations from CACHE/STORAGE")
+          } catch {
+            FeatureRepository.logger.warn("FAILURE: Unable to get all evaluations from CACHE/STORAGE")
+            onCompletion(.failure(CFError.storageError))
+          }
+        }
       case .success(let evaluations):
-        FeatureRepository.logger.debug("SUCCESS: Got all evaluations from cloud")
+        FeatureRepository.logger.debug("SUCCESS: Got all evaluations from CLOUD")
 
         for eval in evaluations {
           let key = CfConstants.Persistance.feature(

--- a/Sources/ff-ios-client-sdk/Version.swift
+++ b/Sources/ff-ios-client-sdk/Version.swift
@@ -2,5 +2,5 @@ import Foundation
 
 class Version {
 
-  static let version: String = "1.3.4"
+  static let version: String = "1.4.0"
 }

--- a/ff-ios-client-sdk.podspec
+++ b/ff-ios-client-sdk.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |ff|
 
   ff.name         = "ff-ios-client-sdk"
-  ff.version      = "1.3.4"
+  ff.version      = "1.4.0"
   ff.summary      = "iOS SDK for Harness Feature Flags Management"
 
   ff.description  = <<-DESC


### PR DESCRIPTION
Added a new option called `failFastOnInit` which tells the SDK to exit immediately with an error instead of attempting to self-heal. When enabled the following are affected:

- If loading evaluations on init fails, call the failed completion handler instead of using previously cached flags
- Disable the network retry logic when the FF endpoint is not reachable.

Version bumped to 1.4.0 to account for API change
Tested with local proxy forcing evaluation endpoint to return 50x HTTP codes