### PR TITLE
fix: [FFM-12586]: Fix excessive logging when flag does not exist

### DIFF
--- a/Sources/ff-ios-client-sdk/API/OpenAPIs/Models.swift
+++ b/Sources/ff-ios-client-sdk/API/OpenAPIs/Models.swift
@@ -61,7 +61,8 @@ public enum CFError: Error {
 	case storageError // 105
 	case streamError(StreamError) //106
 	case cacheError(CfCacheError)
-	
+  case error(any Error)
+
 	public var errorData: ErrorData {
 		switch self {
 			case .authError(let errorResponse):
@@ -97,7 +98,11 @@ public enum CFError: Error {
 				var errorData = self.parseCacheError(cacheError)
 				errorData.title = "Caching Error"
 				return errorData
-		}
+
+
+      case .error(let error):
+      return ErrorData(localizedMessage: "Error: " + String(describing: error), underlyingError: nil, statusCode: nil, data: nil)
+      }
 	}
 	
 	private func parseErrorResponse(_ errorResponse: ErrorResponse?) -> ErrorData {

--- a/Sources/ff-ios-client-sdk/Cache/CfCache.swift
+++ b/Sources/ff-ios-client-sdk/Cache/CfCache.swift
@@ -51,6 +51,12 @@ public final class CfCache: StorageRepositoryProtocol {
         CfCache.log.trace("Fetched from DISK & updated CACHE for key: \(key)")
         cache[key] = val
         return val
+      } catch CFError.cacheError(let error) {
+        if error != .fileDoesNotExist {
+          CfCache.log.warn("CACHE ERROR: \(error)")
+        }
+
+        throw error
       } catch {
         CfCache.log.warn("ERROR: Failed to get value for key \(key): \(error)")
         throw error
@@ -99,7 +105,7 @@ public final class CfCache: StorageRepositoryProtocol {
       throw CFError.cacheError(.invalidDirectory)
     }
     guard fileManager.fileExists(atPath: url.path) else {
-      CfCache.log.warn("ERROR: Failed to read from disk path: \(url.path)")
+      CfCache.log.trace("WARN: Failed to read from disk path: \(url.path)")
       throw CFError.cacheError(.fileDoesNotExist)
     }
     do {

--- a/Sources/ff-ios-client-sdk/CfClient.swift
+++ b/Sources/ff-ios-client-sdk/CfClient.swift
@@ -747,6 +747,7 @@ public class CfClient {
       switch result {
       case .failure(let f):
         CfClient.log.warn("getEvaluationById failed \(f)")
+
         guard let defaultValue = defaultValue else {
 
           completion(nil)

--- a/Sources/ff-ios-client-sdk/Network/FeatureRepository.swift
+++ b/Sources/ff-ios-client-sdk/Network/FeatureRepository.swift
@@ -109,9 +109,12 @@ class FeatureRepository {
           .value
         let evaluation: Evaluation? = try self.storageSource.getValue(forKey: key)
         onCompletion(.success(evaluation!))
-      } catch {
-        FeatureRepository.logger.warn("ERROR: \(error)")
+
+      } catch CfCacheError.fileDoesNotExist {
         onCompletion(.failure(CFError.noDataError))
+      } catch {
+        FeatureRepository.logger.warn("CACHE ERROR: \(error)")
+        onCompletion(.failure(CFError.error(error)))
       }
       return
     }


### PR DESCRIPTION
When an invalid flag name is used, a lot of excessive errors are logged. This fixes reduces them.